### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,17 @@ Of course you can define own backend.
 
 ## Development
 
-You can install requirements with pipenv
+You can install requirements with poetry.
 
 ```shell
-$ pipenv install --dev
+$ poetry install
 ```
 
 ### Test
 
 ```shell
-$ flake8
-$ mypy .
-$ python3 -m unittest discover
+$ poetry poe check  # lint and type check
+$ poetry poe test  # run tests
 ```
 
 # LICENSE


### PR DESCRIPTION
I changed from pipenv to poetry. (in https://github.com/kitsuyui/cachepot/pull/76 )
But README still describes how to install and test with pipenv.
Fix it.
