### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         if: matrix.python == '3.11'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
Reverts kitsuyui/cachepot#136

v4 is currently in beta.

https://github.com/codecov/codecov-action/issues/1089

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```