### PR TITLE
Add uv dependency age policy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dev = [
 [tool.ruff]
 line-length = 79
 
+[tool.uv]
+# Source of truth:
+# https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies
+# PyPI policy in this repo uses a 2 day quarantine window.
+exclude-newer = "2 days"
+
 [build-system]
 requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-04-02T20:14:07.123917Z"
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "async-timeout"
 version = "5.0.1"


### PR DESCRIPTION
## Summary
- add `[tool.uv].exclude-newer = "2 days"` to `pyproject.toml`
- add inline comments that point to the source-of-truth wiki page
- run `uv sync` so the lockfile reflects the new policy

## Reference
- https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies