### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/cachepot/__init__.py
+++ b/cachepot/__init__.py
@@ -1,16 +1,16 @@
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
-from ._version import __version__
 from . import (
     backend,
+    expire,
     serializer,
     store,
-    expire,
 )
+from ._version import __version__
 
 __all__ = [
     "__version__",
     "backend",
+    "expire",
     "serializer",
     "store",
-    "expire",
 ]

--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from typing_extensions import Protocol
 
 from cachepot.expire import ExpireSeconds
@@ -7,9 +5,9 @@ from cachepot.expire import ExpireSeconds
 
 class CacheBackendProtocol(Protocol):
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds
+        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
     ) -> None: ...
 
-    def load(self, key: bytes) -> Optional[bytes]: ...
+    def load(self, key: bytes) -> bytes | None: ...
 
     def delete(self, key: bytes) -> None: ...

--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -1,20 +1,21 @@
+import contextlib
 import hashlib
 import os
 import pathlib
 import time
 from datetime import datetime
-from typing import BinaryIO, Optional, Union, cast
+from typing import BinaryIO, cast
 
 from cachepot.backend import CacheBackendProtocol
 from cachepot.expire import ExpireSeconds, to_timedelta
 
-PathLike = Union[pathlib.Path, str]
+PathLike = pathlib.Path | str
 
 
 class FileSystemCacheBackend(CacheBackendProtocol):
     path: pathlib.Path
 
-    def __init__(self, path: PathLike):
+    def __init__(self, path: PathLike) -> None:
         if isinstance(path, str):
             self.path = pathlib.Path(path)
         else:
@@ -24,7 +25,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         return self.path / hashlib.sha256(key).hexdigest()
 
     def save(
-        self, key: bytes, value: bytes, expire_seconds: ExpireSeconds
+        self, key: bytes, value: bytes, expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         expire_timestamp = time.mktime(expire_at.timetuple())
@@ -34,7 +35,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             f.write(value)
         os.utime(str(realpath), (expire_timestamp, expire_timestamp))
 
-    def load(self, key: bytes) -> Optional[bytes]:
+    def load(self, key: bytes) -> bytes | None:
         path = self.__get_real_path(key)
         if not path.exists() or path.is_dir():
             return None
@@ -44,7 +45,5 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             return f.read()
 
     def delete(self, key: bytes) -> None:
-        try:
+        with contextlib.suppress(FileNotFoundError):
             self.__get_real_path(key).unlink()
-        except FileNotFoundError:
-            pass

--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 import redis
 
@@ -9,18 +9,18 @@ from cachepot.expire import ExpireSeconds, to_timedelta
 class RedisCacheBackend(CacheBackendProtocol):
     redis_connection: redis.Redis
 
-    def __init__(self, redis_connection: redis.Redis):
+    def __init__(self, redis_connection: redis.Redis) -> None:
         self.redis = redis_connection
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds
+        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
     ) -> None:
         with self.redis.pipeline() as pipe:
             pipe.set(key, value)
             pipe.expire(key, to_timedelta(expire_seconds))
             pipe.execute()
 
-    def load(self, key: bytes) -> Optional[bytes]:
+    def load(self, key: bytes) -> bytes | None:
         return cast(bytes, self.redis.get(key))
 
     def delete(self, key: bytes) -> None:

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -1,21 +1,19 @@
 import pathlib
 import sqlite3
 from datetime import datetime
-from typing import Optional, Union, cast
+from typing import cast
 
 from cachepot.backend import CacheBackendProtocol
 from cachepot.expire import ExpireSeconds, to_timedelta
 
-ConnectionLike = Union[str, pathlib.Path, sqlite3.Connection]
+ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
 
 class SQLiteCacheBackend(CacheBackendProtocol):
     conn: sqlite3.Connection
 
-    def __init__(self, conn: ConnectionLike):
-        if isinstance(conn, str):
-            conn = sqlite3.connect(conn)
-        elif isinstance(conn, pathlib.Path):
+    def __init__(self, conn: ConnectionLike) -> None:
+        if isinstance(conn, (str, pathlib.Path)):
             conn = sqlite3.connect(conn)
         conn.text_factory = bytes
         conn.execute(
@@ -24,7 +22,7 @@ CREATE TABLE IF NOT EXISTS cachepot
            ( key BLOB PRIMARY KEY
            , value BLOB
            , expire_at timestamp
-           )"""
+           )""",
         )
         conn.execute(
             """\
@@ -32,12 +30,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
                  ON cachepot
                   ( key
                   , expire_at
-                  )"""
+                  )""",
         )
         self.conn = conn
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds
+        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         self.conn.execute(
@@ -49,7 +47,7 @@ INSERT OR REPLACE INTO cachepot
         )
         self.conn.commit()
 
-    def load(self, key: bytes) -> Optional[bytes]:
+    def load(self, key: bytes) -> bytes | None:
         current_datetime = datetime.now()
         result = self.conn.execute(
             """\

--- a/cachepot/expire.py
+++ b/cachepot/expire.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
-from typing import Union
 
-ExpireSeconds = Union[int, float, timedelta]
+ExpireSeconds = int | float | timedelta
 
 
 def to_timedelta(expire_seconds: ExpireSeconds) -> timedelta:

--- a/cachepot/serializer/json.py
+++ b/cachepot/serializer/json.py
@@ -1,11 +1,11 @@
 import json
-from typing import Any, Dict, List, Union, cast
+from typing import Any, cast
 
 from cachepot.serializer import SerializerProtocol
 
 # JSONType = Union[str, int, float, Dict[str, JSONType], List[JSONType]]
 # https://github.com/python/typing/issues/182
-JSONType = Union[str, int, float, Dict[str, Any], List[Any]]
+JSONType = str | int | float | dict[str, Any] | list[Any]
 
 
 class JSONSerializer(SerializerProtocol[JSONType]):

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from typing_extensions import Protocol
 
@@ -11,18 +12,18 @@ S = TypeVar("S")
 
 
 class CacheStoreProtocol(Protocol[T, S]):
-    def get(self, key: T) -> Optional[S]: ...
+    def get(self, key: T) -> S | None: ...
 
     def put(
         self,
         key: T,
         value: S,
         *,
-        expire_seconds: Optional[ExpireSeconds] = None,
+        expire_seconds: ExpireSeconds | None = None,
     ) -> None: ...
 
     def proxy(
-        self, original_function: Callable[..., S]
+        self, original_function: Callable[..., S],
     ) -> Callable[..., S]: ...
 
     def remove(self, key: T) -> None: ...
@@ -42,7 +43,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         key_serializer: SerializerProtocol[T],
         value_serializer: SerializerProtocol[S],
         default_expire_seconds: ExpireSeconds,
-    ):
+    ) -> None:
         self.namespace = namespace
         self.key_serializer = key_serializer
         self.value_serializer = value_serializer
@@ -53,7 +54,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         serialized_key = self.key_serializer.serialize(key)
         return self.namespace.encode() + b":" + serialized_key
 
-    def get(self, key: T) -> Optional[S]:
+    def get(self, key: T) -> S | None:
         real_key = self.__get_real_key(key)
         loaded = self.backend.load(real_key)
         if loaded is None:
@@ -65,21 +66,21 @@ class CacheStore(CacheStoreProtocol[T, S]):
         key: T,
         value: S,
         *,
-        expire_seconds: Optional[ExpireSeconds] = None,
+        expire_seconds: ExpireSeconds | None = None,
     ) -> None:
         if expire_seconds is None:
             expire_seconds = self.default_expire_seconds
         real_key = self.__get_real_key(key)
         serialized_value = self.value_serializer.serialize(value)
         self.backend.save(
-            real_key, serialized_value, expire_seconds=expire_seconds
+            real_key, serialized_value, expire_seconds=expire_seconds,
         )
 
     def proxy(self, original_function: Callable[..., S]) -> Callable[..., S]:
         def _proxy(
             *args: Any,
             cache_key: T,
-            expire_seconds: Optional[ExpireSeconds] = None,
+            expire_seconds: ExpireSeconds | None = None,
             **kwargs: Any,
         ) -> S:
             cached_result = self.get(cache_key)

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -15,7 +15,7 @@ class SimpleFileSystemCacheStore(CacheStore[str, Any]):
         namespace: str,
         *,
         directory: str = 'tmp',
-    ):
+    ) -> None:
         super().__init__(
             namespace=namespace,
             key_serializer=StringSerializer(),
@@ -33,7 +33,7 @@ class FileSystemJSONCacheStore(CacheStore[str, JSONType]):
         namespace: str,
         *,
         directory: str = 'tmp',
-    ):
+    ) -> None:
         super().__init__(
             namespace=namespace,
             key_serializer=StringSerializer(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,44 @@ dev = [
 [tool.ruff]
 line-length = 79
 
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+ignore = [
+    "ANN401",
+    "S301",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"example/**/*.py" = [
+    "S101",
+]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S101",
+]
+
 [tool.uv]
 # Source of truth:
 # https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test` (fails locally unless Redis is available on `localhost:6379`)
