### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -37,12 +37,16 @@ class FileSystemCacheBackend(CacheBackendProtocol):
 
     def load(self, key: bytes) -> bytes | None:
         path = self.__get_real_path(key)
-        if not path.exists() or path.is_dir():
-            return None
-        if path.stat().st_mtime < time.mktime(datetime.now().timetuple()):
+        if not self.__can_load(path):
             return None
         with cast(BinaryIO, path.open("rb")) as f:
             return f.read()
+
+    def __can_load(self, path: pathlib.Path) -> bool:
+        return path.is_file() and not self.__is_expired(path)
+
+    def __is_expired(self, path: pathlib.Path) -> bool:
+        return path.stat().st_mtime < time.mktime(datetime.now().timetuple())
 
     def delete(self, key: bytes) -> None:
         with contextlib.suppress(FileNotFoundError):

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -83,15 +83,32 @@ class CacheStore(CacheStoreProtocol[T, S]):
             expire_seconds: ExpireSeconds | None = None,
             **kwargs: Any,
         ) -> S:
-            cached_result = self.get(cache_key)
-            if cached_result is not None:
-                return cached_result
-
-            result = original_function(*args, **kwargs)
-            self.put(cache_key, result, expire_seconds=expire_seconds)
-            return result
+            return self.__load_or_compute(
+                cache_key=cache_key,
+                expire_seconds=expire_seconds,
+                original_function=original_function,
+                args=args,
+                kwargs=kwargs,
+            )
 
         return _proxy
+
+    def __load_or_compute(
+        self,
+        *,
+        cache_key: T,
+        expire_seconds: ExpireSeconds | None,
+        original_function: Callable[..., S],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> S:
+        cached_result = self.get(cache_key)
+        if cached_result is not None:
+            return cached_result
+
+        result = original_function(*args, **kwargs)
+        self.put(cache_key, result, expire_seconds=expire_seconds)
+        return result
 
     def remove(self, key: T) -> None:
         real_key = self.__get_real_key(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 3
+max-complexity = 2
 
 [tool.uv]
 # Source of truth:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ ignore = [
     "S101",
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 3
+
 [tool.uv]
 # Source of truth:
 # https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 3`
- lower the limit to `2`
- extract cache loading and proxy computation helpers without changing the public API

## Testing
- `uv run poe check`
- `uv run pytest tests/test_store.py tests/backend/test_filesystem.py tests/backend/test_sqlite.py`

## Notes
- `uv run poe test` still requires a local Redis server for `tests/backend/test_redis.py`