### PR TITLE
Fix Python version check in CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,7 +37,9 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        run: |
+          uv python pin ${{ matrix.python }}
+          uv sync
 
       - name: Lint
         run: uv run poe check
@@ -46,7 +48,7 @@ jobs:
         run: |
           actual_version=$(uv run python --version)
           expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          if [[ "$actual_version" != *"$expected_version"* ]]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
@@ -56,4 +58,3 @@ jobs:
   
       - name: Coverage
         run: uv run poe coverage-xml
-


### PR DESCRIPTION
## Summary

- Pin uv's Python version to the matrix entry before syncing dependencies.
- Invert the Python version check so it fails only on mismatches.

## Verification

- Parsed `.github/workflows/python-test.yml` as YAML.
- Ran `git diff --check`.
