### PR TITLE
ci: reduce publish workflow permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,5 +1,8 @@
 name: Packaging
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -12,6 +15,8 @@ env:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add workflow/job-level permissions to `pypi-publish.yml` to narrow publish scope and avoid running without explicit permission boundaries.

## Validation

- `uv sync`
- `uv run poe check`
- `uv run poe test` (2 failing tests in `tests/backend/test_redis.py` due local Redis dependency not available)
- `uv run pytest --ignore=tests/backend/test_redis.py` (pass)
