### PR TITLE
fix: create filesystem cache directory on save

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -31,6 +31,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         expire_timestamp = time.mktime(expire_at.timetuple())
 
         realpath = self.__get_real_path(key)
+        realpath.parent.mkdir(parents=True, exist_ok=True)
         with cast(BinaryIO, realpath.open("wb")) as f:
             f.write(value)
         os.utime(str(realpath), (expire_timestamp, expire_timestamp))

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -23,6 +23,18 @@ def test_various_pathlike() -> None:
         assert cachestore.load(b"3") is None
 
 
+def test_save_creates_missing_cache_directory() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir) / "missing-cache"
+        cachestore = FileSystemCacheBackend(cache_dir)
+
+        assert not cache_dir.exists()
+        cachestore.save(b"1", b"2", expire_seconds=1)
+
+        assert cache_dir.is_dir()
+        assert cachestore.load(b"1") == b"2"
+
+
 def test_expire() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         cachestore = FileSystemCacheBackend(pathlib.Path(tmpdir))


### PR DESCRIPTION
## Summary

- Create the filesystem cache directory before writing cache entries.
- Add a regression test that saves into a missing cache directory and verifies the value can be loaded.

## Root cause

`FileSystemCacheBackend.save()` resolved the cache file path and opened it directly. When the configured cache directory did not exist yet, the first save raised `FileNotFoundError` instead of initializing the cache storage path.

## Validation

- `uv run pytest tests/backend/test_filesystem.py`
- `uv run poe check`
- `uv run poe test`