### PR TITLE
Pin write-capable reusable workflows

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@a7071a4635eaece62696cd7132306616ce283c47

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary

- Pin write-capable reusable workflow references to a specific commit SHA.
- Keep the existing triggers and permissions unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; %w[.github/workflows/happy.yml .github/workflows/gitignore-in.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'\n- actionlint .github/workflows/happy.yml .github/workflows/gitignore-in.yml