### PR TITLE
Pin octocov workflow supply chain refs

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       redis:
-        image: redis
+        image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -45,7 +45,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary

- Pin the octocov workflow Redis service image to the Redis 8.6.3 digest.
- Pin the workflow actions to full commit SHAs.
- Keep the original action tag names as inline comments for review and future updates.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/octocov.yml`
- `actionlint .github/workflows/octocov.yml`
- `docker buildx imagetools inspect redis:8.6.3`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`

## Notes

Local tests report existing sqlite datetime adapter deprecation warnings on Python 3.13. Before rerunning coverage locally, I cleared the local Redis DB because a stale key from the local Redis instance caused the first coverage run to observe pre-existing cache data. The GitHub workflow uses a fresh Redis service container.