### PR TITLE
Fix three cache-correctness gaps in store and backends

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -2,6 +2,7 @@ import contextlib
 import hashlib
 import os
 import pathlib
+import tempfile
 import time
 from datetime import datetime
 from typing import BinaryIO, cast
@@ -25,16 +26,36 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         return self.path / hashlib.sha256(key).hexdigest()
 
     def save(
-        self, key: bytes, value: bytes, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         expire_timestamp = time.mktime(expire_at.timetuple())
 
         realpath = self.__get_real_path(key)
         realpath.parent.mkdir(parents=True, exist_ok=True)
-        with cast(BinaryIO, realpath.open("wb")) as f:
-            f.write(value)
-        os.utime(str(realpath), (expire_timestamp, expire_timestamp))
+
+        # Atomic write: stage the payload in a sibling temp file, stamp
+        # its mtime to the expiration time, then ``os.replace`` it onto
+        # the final path. A crash before the rename leaves the temp file
+        # behind but never exposes a partial or stale-mtime cache entry
+        # at the real path.
+        fd, tmpname = tempfile.mkstemp(
+            prefix=".tmp-",
+            dir=str(realpath.parent),
+        )
+        tmppath = pathlib.Path(tmpname)
+        try:
+            with cast(BinaryIO, os.fdopen(fd, "wb")) as f:
+                f.write(value)
+            os.utime(str(tmppath), (expire_timestamp, expire_timestamp))
+            tmppath.replace(realpath)
+        except BaseException:
+            with contextlib.suppress(FileNotFoundError):
+                tmppath.unlink()
+            raise
 
     def load(self, key: bytes) -> bytes | None:
         path = self.__get_real_path(key)

--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -13,12 +13,16 @@ class RedisCacheBackend(CacheBackendProtocol):
         self.redis = redis_connection
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None:
-        with self.redis.pipeline() as pipe:
-            pipe.set(key, value)
-            pipe.expire(key, to_timedelta(expire_seconds))
-            pipe.execute()
+        # ``SET key value EX seconds`` is a single Redis command, so the
+        # value and its TTL land together. The previous pipeline form
+        # could leave the key without a TTL if EXPIRE failed after SET.
+        self.redis.set(key, value, ex=to_timedelta(expire_seconds))
 
     def load(self, key: bytes) -> bytes | None:
         return cast(bytes, self.redis.get(key))

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -23,7 +23,8 @@ class CacheStoreProtocol(Protocol[T, S]):
     ) -> None: ...
 
     def proxy(
-        self, original_function: Callable[..., S],
+        self,
+        original_function: Callable[..., S],
     ) -> Callable[..., S]: ...
 
     def remove(self, key: T) -> None: ...
@@ -73,7 +74,9 @@ class CacheStore(CacheStoreProtocol[T, S]):
         real_key = self.__get_real_key(key)
         serialized_value = self.value_serializer.serialize(value)
         self.backend.save(
-            real_key, serialized_value, expire_seconds=expire_seconds,
+            real_key,
+            serialized_value,
+            expire_seconds=expire_seconds,
         )
 
     def proxy(self, original_function: Callable[..., S]) -> Callable[..., S]:
@@ -102,9 +105,13 @@ class CacheStore(CacheStoreProtocol[T, S]):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ) -> S:
-        cached_result = self.get(cache_key)
-        if cached_result is not None:
-            return cached_result
+        # Inspect the backend directly so a stored ``None`` value is
+        # distinguishable from a cache miss (the backend returns ``None``
+        # only when the key is absent; a stored value is always bytes).
+        real_key = self.__get_real_key(cache_key)
+        loaded = self.backend.load(real_key)
+        if loaded is not None:
+            return self.value_serializer.deserialize(loaded)
 
         result = original_function(*args, **kwargs)
         self.put(cache_key, result, expire_seconds=expire_seconds)

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -1,8 +1,10 @@
 import pathlib
 import tempfile
 import time
+from datetime import datetime
 
 from cachepot.backend.filesystem import FileSystemCacheBackend
+from cachepot.expire import to_timedelta
 
 
 def test_various_pathlike() -> None:
@@ -42,3 +44,36 @@ def test_expire() -> None:
         assert cachestore.load(b"1") == b"2"
         time.sleep(2)
         assert cachestore.load(b"1") is None
+
+
+def test_save_leaves_no_temp_files() -> None:
+    """The atomic-rename path should leave the cache directory holding
+    only the final cache entries after a successful save."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        cachestore.save(b"k1", b"v1", expire_seconds=60)
+        cachestore.save(b"k2", b"v2", expire_seconds=60)
+
+        names = sorted(p.name for p in cache_dir.iterdir())
+        assert len(names) == 2
+        assert all(not n.startswith(".tmp-") for n in names)
+
+
+def test_save_sets_expiration_mtime_on_overwrite() -> None:
+    """Overwriting an entry must end with the new expiration mtime, not
+    the kernel-default ``st_mtime`` of an in-flight write."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        cachestore.save(b"k", b"old", expire_seconds=1)
+        time.sleep(1.1)
+        # The old entry is now expired; overwrite with a far-future TTL.
+        cachestore.save(b"k", b"new", expire_seconds=3600)
+
+        (entry,) = [p for p in cache_dir.iterdir() if p.is_file()]
+        future_threshold = (
+            datetime.now() + to_timedelta(60)
+        ).timestamp()
+        assert entry.stat().st_mtime >= future_threshold
+        assert cachestore.load(b"k") == b"new"

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -1,4 +1,5 @@
 import time
+from datetime import timedelta
 
 import redis
 
@@ -22,3 +23,32 @@ def test_expire() -> None:
     assert cachestore.load(b"1") == b"2"
     time.sleep(2)
     assert cachestore.load(b"1") is None
+
+
+def test_save_sets_ttl_atomically() -> None:
+    """``SET`` and the TTL must be applied in one command; a server-side
+    failure between SET and EXPIRE used to leak persistent keys."""
+    r = redis.Redis(host="localhost", port=6379, db=0)
+    cachestore = RedisCacheBackend(r)
+    cachestore.save(b"ttl-check", b"value", expire_seconds=60)
+    try:
+        # ``TTL`` returns -1 for "no TTL" and -2 for "no key". A correct
+        # implementation always lands somewhere in (0, 60].
+        ttl = r.ttl(b"ttl-check")
+        assert 0 < ttl <= 60
+    finally:
+        cachestore.delete(b"ttl-check")
+
+
+def test_save_accepts_timedelta_expire_seconds() -> None:
+    """The backend should still honour ``timedelta`` inputs from
+    ``ExpireSeconds`` after the SET+EX consolidation."""
+    r = redis.Redis(host="localhost", port=6379, db=0)
+    cachestore = RedisCacheBackend(r)
+    cachestore.save(b"td-key", b"v", expire_seconds=timedelta(seconds=30))
+    try:
+        ttl = r.ttl(b"td-key")
+        assert 0 < ttl <= 30
+        assert cachestore.load(b"td-key") == b"v"
+    finally:
+        cachestore.delete(b"td-key")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -29,3 +29,28 @@ def test_basis() -> None:
         time.sleep(2)
         assert cachestore.get("y") is None
         assert cachestore.proxy(lambda: 3)(cache_key="y") == 3
+
+
+def test_proxy_caches_none_return_value() -> None:
+    """A function whose result is ``None`` must only be executed once
+    per cached call, even though ``None`` is also the sentinel the
+    serializer is allowed to round-trip."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cachestore = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+
+        call_count = 0
+
+        def returns_none() -> None:
+            nonlocal call_count
+            call_count += 1
+
+        proxied = cachestore.proxy(returns_none)
+        assert proxied(cache_key="none-key") is None
+        assert proxied(cache_key="none-key") is None
+        assert call_count == 1


### PR DESCRIPTION
## Summary

Three independent gaps were breaking the cache trust contract: store hits collapsed `None` values with misses, the filesystem backend's write was not crash-safe, and the redis backend split `SET` and `EXPIRE` across non-transactional pipeline commands.

### Gap 1 – `None` cannot round-trip through `proxy`

`CacheStore.__load_or_compute` checked `get(cache_key) is not None`. When a wrapped function returned `None`, `put` stored the serialized `None` but the next call still went down the miss branch, so the cache offered no benefit and the original function ran every time.

Fix: inspect `backend.load(real_key)` directly inside `__load_or_compute`. The backend returns `None` only when the key is absent; a stored value is always bytes (e.g. pickle’s `b'\x80\x04N.'` for `None`), so hit-with-`None` is now distinguishable from a miss.

### Gap 2 – filesystem `save` was not crash-safe

`FileSystemCacheBackend.save` opened the real path in `"wb"` mode (truncating any prior entry) and only stamped the expiration mtime with `os.utime` after the write. A crash between the two calls left a partial file whose `st_mtime` defaulted to "now", which `__is_expired` treats as fresh — so the next `load` returned partial bytes that the serializer then failed to decode.

Fix: write the payload to a sibling temp file via `tempfile.mkstemp`, stamp `os.utime` on the temp file, then atomically `Path.replace` it onto the real path. A crash before the rename leaves a `.tmp-…` file behind but never publishes a partial entry.

### Gap 3 – redis `save` split `SET` and `EXPIRE`

`RedisCacheBackend.save` used `pipeline()` without `transaction=True`, so `SET` and `EXPIRE` were two independent commands. If `EXPIRE` failed for any server-side reason (memory limit, OOM kill, partition between the two RTTs) the key persisted without a TTL.

Fix: use the single `self.redis.set(key, value, ex=...)` form. Server-side atomicity is now guaranteed by the Redis protocol.

## Test plan

- [x] `uv run poe check` (ruff + mypy)
- [x] `uv run poe test` (19 passed, including 3 new regression tests)
- [x] Added regression tests:
  - `tests/test_store.py::test_proxy_caches_none_return_value` – the wrapped function runs once even when it returns `None`.
  - `tests/backend/test_filesystem.py::test_save_leaves_no_temp_files` – no `.tmp-…` siblings remain after a successful save.
  - `tests/backend/test_filesystem.py::test_save_sets_expiration_mtime_on_overwrite` – overwrites land with the new expiration mtime, not the kernel default.
  - `tests/backend/test_redis.py::test_save_sets_ttl_atomically` and `test_save_accepts_timedelta_expire_seconds` – TTL is always set after `save`.