### PR TITLE
Expose proxy cache key requirement in types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ pip install cachepot
 ### Proxy method
 
 ```python
-result = store.proxy(some_func)(some_args)
+result = store.proxy(some_func)(some_args, cache_key=some_arg)
 ```
 
 is the equivalent of
@@ -46,11 +46,12 @@ is the equivalent of
 result = store.get(some_arg)
 if result is None:
     result = some_func(some_args)
-    store.set(result)
+    store.put(some_arg, result)
 ```
 
 In short, this works as proxy. This helps to make codes straight forward.
-proxy method can be passed two arguments `cache_key` and `expire_seconds`.
+The proxied function requires the keyword-only argument `cache_key` and
+can also accept `expire_seconds`.
 
 ## Core idea
 

--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -5,7 +5,11 @@ from cachepot.expire import ExpireSeconds
 
 class CacheBackendProtocol(Protocol):
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None: ...
 
     def load(self, key: bytes) -> bytes | None: ...

--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -29,6 +29,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         self,
         key: bytes,
         value: bytes,
+        *,
         expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -35,7 +35,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
         self.conn = conn
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         self.conn.execute(

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -9,6 +9,17 @@ from cachepot.serializer import SerializerProtocol
 
 T = TypeVar("T", contravariant=True)
 S = TypeVar("S")
+S_co = TypeVar("S_co", covariant=True)
+
+
+class CacheProxyProtocol(Protocol[T, S_co]):
+    def __call__(
+        self,
+        *args: Any,
+        cache_key: T,
+        expire_seconds: ExpireSeconds | None = None,
+        **kwargs: Any,
+    ) -> S_co: ...
 
 
 class CacheStoreProtocol(Protocol[T, S]):
@@ -25,7 +36,7 @@ class CacheStoreProtocol(Protocol[T, S]):
     def proxy(
         self,
         original_function: Callable[..., S],
-    ) -> Callable[..., S]: ...
+    ) -> CacheProxyProtocol[T, S]: ...
 
     def remove(self, key: T) -> None: ...
 
@@ -79,7 +90,10 @@ class CacheStore(CacheStoreProtocol[T, S]):
             expire_seconds=expire_seconds,
         )
 
-    def proxy(self, original_function: Callable[..., S]) -> Callable[..., S]:
+    def proxy(
+        self,
+        original_function: Callable[..., S],
+    ) -> CacheProxyProtocol[T, S]:
         def _proxy(
             *args: Any,
             cache_key: T,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,10 +1,22 @@
 import tempfile
 import time
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from typing_extensions import assert_type
 
 from cachepot.backend.filesystem import FileSystemCacheBackend
 from cachepot.serializer.pickle import PickleSerializer
 from cachepot.serializer.str import StringSerializer
-from cachepot.store import CacheStore
+from cachepot.store import CacheProxyProtocol, CacheStore
+
+if TYPE_CHECKING:
+    typed_proxy = cast(CacheProxyProtocol[str, int], None)
+    assert_type(typed_proxy(1, cache_key="key"), int)
+
+    typed_store = cast(CacheStore[str, int], None)
+    proxied_increment = typed_store.proxy(lambda value: value + 1)
+    assert_type(proxied_increment(1, cache_key="key"), int)
 
 
 def test_basis() -> None:
@@ -54,3 +66,18 @@ def test_proxy_caches_none_return_value() -> None:
         assert proxied(cache_key="none-key") is None
         assert proxied(cache_key="none-key") is None
         assert call_count == 1
+
+
+def test_proxy_requires_cache_key_at_runtime() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cachestore = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+
+        proxied = cachestore.proxy(lambda: 3)
+        with pytest.raises(TypeError, match="cache_key"):
+            proxied()  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

- Add a `CacheProxyProtocol` return type for `CacheStore.proxy()` so the required keyword-only `cache_key` argument is visible to type checkers
- Align `FileSystemCacheBackend.save()` with the backend protocol by making `expire_seconds` keyword-only
- Update the README proxy example and add tests for the proxy call contract

## Verification

- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `git diff --check`