### PR TITLE
docs: add security warning for PickleSerializer and remove global S301 suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ $ pip install cachepot
 >>> store.put({'some': 'short expiring key'}, {'some': 'value'}, expire_seconds=10)
 ```
 
+> **Security note**: `PickleSerializer` uses Python's `pickle` module, which can
+> execute arbitrary code during deserialization. Only use it when the cache
+> backend storage is fully under your control and trusted. For untrusted
+> environments, prefer `JsonSerializer` or `MsgpackSerializer` instead.
+
 ### Proxy method
 
 ```python

--- a/cachepot/serializer/pickle.py
+++ b/cachepot/serializer/pickle.py
@@ -5,8 +5,26 @@ from cachepot.serializer import SerializerProtocol
 
 
 class PickleSerializer(SerializerProtocol[Any]):
+    """Pickle-based serializer.
+
+    Warning:
+        ``pickle`` can execute arbitrary code during deserialization.
+        Only use this serializer with cache backends whose storage you fully
+        control and trust. Never deserialize data received from untrusted
+        sources (e.g. shared caches, user-supplied input).
+        Consider :class:`cachepot.serializer.json.JsonSerializer` or
+        :class:`cachepot.serializer.msgpack.MsgpackSerializer` for
+        untrusted environments.
+    """
+
     def serialize(self, data: Any) -> bytes:
         return pickle.dumps(data)
 
     def deserialize(self, serialized_data: bytes) -> Any:
-        return pickle.loads(serialized_data)
+        """Deserialize bytes produced by :meth:`serialize`.
+
+        Warning:
+            Calls ``pickle.loads``, which can execute arbitrary code.
+            Only pass data from trusted sources.
+        """
+        return pickle.loads(serialized_data)  # noqa: S301

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ select = [
 ]
 ignore = [
     "ANN401",
-    "S301",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Summary

- Add docstrings to `PickleSerializer` and `deserialize()` that explicitly warn about the risks of `pickle.loads()`.
- Remove the global `S301` (`suspicious-pickle-usage`) suppression from `pyproject.toml` and move it to the specific `pickle.loads()` line as `# noqa: S301`.
- Add a security note to the `README.md` usage example and recommend `JsonSerializer` / `MsgpackSerializer` for untrusted environments.

## Test plan

- [x] `ruff check cachepot tests` passes
- [x] `pytest` passes (19 passed)
- [ ] CI passes
