### PR TITLE
fix: add delete_expired() to SQLiteCacheBackend to purge stale rows

### DIFF
--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -5,7 +5,11 @@ from cachepot.expire import ExpireSeconds
 
 class CacheBackendProtocol(Protocol):
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None: ...
 
     def load(self, key: bytes) -> bytes | None: ...

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -35,7 +35,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
         self.conn = conn
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         self.conn.execute(
@@ -70,3 +74,15 @@ INSERT OR REPLACE INTO cachepot
             (key,),
         )
         self.conn.commit()
+
+    def delete_expired(self) -> int:
+        """Delete all expired rows and return the number of deleted rows."""
+        cur = self.conn.execute(
+            """\
+        DELETE
+          FROM cachepot
+         WHERE expire_at <= ?""",
+            (datetime.now(),),
+        )
+        self.conn.commit()
+        return cur.rowcount

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -30,3 +30,25 @@ def test_expire() -> None:
         assert cachestore.load(b"1") == b"2"
         time.sleep(2)
         assert cachestore.load(b"1") is None
+
+
+def test_delete_expired() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        cachestore.save(b"expired", b"value", expire_seconds=1)
+        cachestore.save(b"live", b"value", expire_seconds=60)
+
+        time.sleep(2)
+
+        # expired row is filtered by load() but still physically present
+        assert cachestore.load(b"expired") is None
+        assert cachestore.load(b"live") == b"value"
+
+        deleted = cachestore.delete_expired()
+        assert deleted == 1
+
+        # live row is unaffected
+        assert cachestore.load(b"live") == b"value"
+
+        # calling again with nothing expired returns 0
+        assert cachestore.delete_expired() == 0


### PR DESCRIPTION
## Summary

- Add `SQLiteCacheBackend.delete_expired()` to bulk-delete rows where `expire_at <= now` and return the number of deleted rows.
- Keep `CacheBackendProtocol` unchanged; `delete_expired()` is exposed as a SQLite-specific operation.
- Apply formatter output to the `CacheBackendProtocol.save` signature in `cachepot/backend/__init__.py`.
- Add `test_delete_expired` to verify the difference between filtering expired rows and physically deleting them.

## Motivation

`load()` filters rows with `expire_at > now`, but expired rows are not physically deleted. Workloads with many distinct keys can therefore grow the SQLite file without bound. Adding `delete_expired()` gives users an explicit method they can call during periodic maintenance.

## Scope note

This branch currently also contains the PickleSerializer security warning changes from #523, so the diff includes `README.md`, `cachepot/serializer/pickle.py`, and `pyproject.toml` in addition to the SQLite cleanup files.

## Test plan

- [x] `test_delete_expired`: expired rows are deleted by `delete_expired()`
- [x] `test_delete_expired`: unexpired rows are not affected
- [x] `test_delete_expired`: the deleted row count is returned correctly
- [x] `test_delete_expired`: a second call returns 0
- [x] All existing tests pass (`uv run poe test`)
