### PR TITLE
fix: replace typing_extensions.Protocol with stdlib typing.Protocol

### DIFF
--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -1,11 +1,15 @@
-from typing_extensions import Protocol
+from typing import Protocol
 
 from cachepot.expire import ExpireSeconds
 
 
 class CacheBackendProtocol(Protocol):
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None: ...
 
     def load(self, key: bytes) -> bytes | None: ...

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -35,7 +35,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
         self.conn = conn
 
     def save(
-        self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
+        self,
+        key: bytes,
+        value: bytes,
+        *,
+        expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         self.conn.execute(

--- a/cachepot/serializer/__init__.py
+++ b/cachepot/serializer/__init__.py
@@ -1,6 +1,4 @@
-from typing import TypeVar
-
-from typing_extensions import Protocol
+from typing import Protocol, TypeVar
 
 T = TypeVar("T")
 

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,7 +1,5 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, TypeVar
 
 from cachepot.backend import CacheBackendProtocol
 from cachepot.expire import ExpireSeconds


### PR DESCRIPTION
`typing.Protocol` has been available in the stdlib since Python 3.8.
This package declares `requires-python = ">=3.10"`, so `typing_extensions`
is not needed for `Protocol`.

Replace `from typing_extensions import Protocol` with `from typing import Protocol`
in all three modules that used it. Also consolidate the imports and apply ruff
format for consistent style.

- `cachepot/backend/__init__.py`
- `cachepot/serializer/__init__.py`
- `cachepot/store/__init__.py`