### PR TITLE
fix: prevent duplicate function execution under concurrent cache misses

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,3 +1,4 @@
+import threading
 from collections.abc import Callable
 from typing import Any, TypeVar
 
@@ -50,6 +51,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         self.value_serializer = value_serializer
         self.backend = backend
         self.default_expire_seconds = default_expire_seconds
+        self._lock = threading.Lock()
 
     def __get_real_key(self, key: T) -> bytes:
         serialized_key = self.key_serializer.serialize(key)
@@ -109,13 +111,14 @@ class CacheStore(CacheStoreProtocol[T, S]):
         # distinguishable from a cache miss (the backend returns ``None``
         # only when the key is absent; a stored value is always bytes).
         real_key = self.__get_real_key(cache_key)
-        loaded = self.backend.load(real_key)
-        if loaded is not None:
-            return self.value_serializer.deserialize(loaded)
+        with self._lock:
+            loaded = self.backend.load(real_key)
+            if loaded is not None:
+                return self.value_serializer.deserialize(loaded)
 
-        result = original_function(*args, **kwargs)
-        self.put(cache_key, result, expire_seconds=expire_seconds)
-        return result
+            result = original_function(*args, **kwargs)
+            self.put(cache_key, result, expire_seconds=expire_seconds)
+            return result
 
     def remove(self, key: T) -> None:
         real_key = self.__get_real_key(key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,8 @@
+import concurrent.futures
+import functools
 import tempfile
 import time
+from collections.abc import Callable
 
 from cachepot.backend.filesystem import FileSystemCacheBackend
 from cachepot.serializer.pickle import PickleSerializer
@@ -9,7 +12,6 @@ from cachepot.store import CacheStore
 
 def test_basis() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-
         cachestore = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
@@ -54,3 +56,49 @@ def test_proxy_caches_none_return_value() -> None:
         assert proxied(cache_key="none-key") is None
         assert proxied(cache_key="none-key") is None
         assert call_count == 1
+
+
+class _CountingFunction:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def __call__(self) -> int:
+        self.call_count += 1
+        time.sleep(0.05)
+        return 42
+
+
+def _invoke(fn: Callable[[], int]) -> int:
+    return fn()
+
+
+def _run_concurrent(fn: Callable[[], int], n: int) -> list[int]:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as pool:
+        return list(pool.map(_invoke, [fn] * n))
+
+
+def test_proxy_no_double_execution_under_concurrency() -> None:
+    """Concurrent cache misses on the same key must not execute the
+    original function more than once.
+
+    All workers start simultaneously; the first acquires the store lock,
+    computes the result (with a brief sleep so others block on the lock),
+    stores it, then releases.  The remaining workers find a cache hit and
+    return without re-executing the function.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        fn = _CountingFunction()
+        proxied = functools.partial(
+            store.proxy(fn),
+            cache_key="concurrent-key",
+        )
+        results = _run_concurrent(proxied, 8)
+        assert fn.call_count == 1
+        assert results == [42] * 8


### PR DESCRIPTION
## Summary

`CacheStore.__load_or_compute` performed the check-then-act sequence
(backend.load → execute function → backend.save) without any
synchronization.  When two threads hit the same cache miss simultaneously,
both executed the original function — which can be expensive or have
side-effects such as external API calls, DB writes, or billing events.

## Changes

- `cachepot/store/__init__.py`: add `self._lock = threading.Lock()` in
  `__init__` and wrap the body of `__load_or_compute` with `with self._lock:`.
  The lock serializes concurrent misses on any key within the same store,
  so only the first thread executes the function; the rest find the cached
  result on re-check.
- `tests/test_store.py`: add `test_proxy_no_double_execution_under_concurrency`
  — 8 workers call the same proxy simultaneously against a key that is not
  yet cached; asserts the underlying function is invoked exactly once.

## Trade-offs

All keys in the same `CacheStore` instance share one lock.  Concurrent
misses on *different* keys are also serialized, which may reduce throughput
under heavy concurrent load.  Per-key locking would recover that
parallelism but requires more complex bookkeeping; this finding is fixed
with the minimal change.