### PR TITLE
fix: add check_same_thread=False and threading.Lock to SQLiteCacheBackend

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -1,5 +1,6 @@
 import pathlib
 import sqlite3
+import threading
 from datetime import datetime
 from typing import cast
 
@@ -11,10 +12,12 @@ ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
 class SQLiteCacheBackend(CacheBackendProtocol):
     conn: sqlite3.Connection
+    _lock: threading.Lock
 
     def __init__(self, conn: ConnectionLike) -> None:
         if isinstance(conn, (str, pathlib.Path)):
-            conn = sqlite3.connect(conn)
+            conn = sqlite3.connect(conn, check_same_thread=False)
+        self._lock = threading.Lock()
         conn.text_factory = bytes
         conn.execute(
             """\
@@ -38,35 +41,38 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
         self, key: bytes, value: bytes, *, expire_seconds: ExpireSeconds,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
-        self.conn.execute(
-            """\
+        with self._lock:
+            self.conn.execute(
+                """\
 INSERT OR REPLACE INTO cachepot
             (key, value, expire_at)
      VALUES (?, ?, ?)""",
-            (key, value, expire_at),
-        )
-        self.conn.commit()
+                (key, value, expire_at),
+            )
+            self.conn.commit()
 
     def load(self, key: bytes) -> bytes | None:
         current_datetime = datetime.now()
-        result = self.conn.execute(
-            """\
+        with self._lock:
+            result = self.conn.execute(
+                """\
         SELECT value
           FROM cachepot
          WHERE key = ?
            AND expire_at > ?""",
-            (key, current_datetime),
-        ).fetchone()
+                (key, current_datetime),
+            ).fetchone()
         if result:
             return cast(bytes, result[0])
         return None
 
     def delete(self, key: bytes) -> None:
-        self.conn.execute(
-            """\
+        with self._lock:
+            self.conn.execute(
+                """\
         DELETE
           FROM cachepot
          WHERE key = ?""",
-            (key,),
-        )
-        self.conn.commit()
+                (key,),
+            )
+            self.conn.commit()

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import pathlib
 import tempfile
 import time
@@ -30,3 +31,23 @@ def test_expire() -> None:
         assert cachestore.load(b"1") == b"2"
         time.sleep(2)
         assert cachestore.load(b"1") is None
+
+
+def _thread_worker(cachestore: SQLiteCacheBackend, i: int) -> None:
+    key = str(i).encode()
+    cachestore.save(key, key, expire_seconds=10)
+    assert cachestore.load(key) == key
+    cachestore.delete(key)
+
+
+def test_sqlite_thread_safe() -> None:
+    import functools
+
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        worker = functools.partial(_thread_worker, cachestore)
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=8)
+        with pool as executor:
+            futures = [executor.submit(worker, i) for i in range(32)]
+        results = [fut.result() for fut in futures]
+    assert results == [None] * 32


### PR DESCRIPTION
## Summary

- Add `check_same_thread=False` when `SQLiteCacheBackend.__init__` creates a SQLite connection from a `str` or `Path`.
- Protect all database operations (`save`, `load`, and `delete`) with `threading.Lock`.
- Fix `ProgrammingError` in multi-threaded environments such as Flask/FastAPI workers or `ThreadPoolExecutor`.

## Background

`sqlite3.connect()` enforces same-thread usage by default, so calling backend methods from a thread other than the connection creator raised `ProgrammingError: SQLite objects created in a thread can only be used in that same thread.` Unlike the filesystem and Redis backends, `SQLiteCacheBackend` had an implicit thread restriction.

## Changes

- `cachepot/backend/sqlite.py`: add `check_same_thread=False`, add `threading.Lock`, and guard all operations with `with self._lock:`.
- `tests/backend/test_sqlite.py`: add `test_sqlite_thread_safe`, which verifies 32 concurrent accesses using `ThreadPoolExecutor(max_workers=8)`.

## Test plan

- [x] Existing tests (`test_sqlite_connection`, `test_expire`) pass
- [x] New test (`test_sqlite_thread_safe`) passes with 8 threads and 32 accesses
- [x] `ruff check` / `mypy` pass
