### PR TITLE
Align Redis backend connection attribute

### DIFF
--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -1,15 +1,15 @@
 from typing import cast
 
-import redis
+from redis import Redis
 
 from cachepot.backend import CacheBackendProtocol
 from cachepot.expire import ExpireSeconds, to_timedelta
 
 
 class RedisCacheBackend(CacheBackendProtocol):
-    redis_connection: redis.Redis
+    redis: Redis
 
-    def __init__(self, redis_connection: redis.Redis) -> None:
+    def __init__(self, redis_connection: Redis) -> None:
         self.redis = redis_connection
 
     def save(

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -9,6 +9,7 @@ from cachepot.backend.redis import RedisCacheBackend
 def test_various_connection_like() -> None:
     r = redis.Redis(host="localhost", port=6379, db=0)
     cachestore = RedisCacheBackend(r)
+    assert cachestore.redis is r
     assert cachestore.load(b"1") is None
     cachestore.save(b"1", b"2", expire_seconds=1)
     assert cachestore.load(b"1") == b"2"


### PR DESCRIPTION
## Summary
- Rename the Redis backend instance annotation to match the attribute assigned by the constructor
- Import `Redis` directly so the connection type remains available after the attribute is named `redis`
- Add a Redis backend test assertion that the backend stores the provided connection on `redis`

## Tests
- uv run poe check
- uv run poe test
