### PR TITLE
Stabilize PickleSerializer protocol

### DIFF
--- a/cachepot/serializer/pickle.py
+++ b/cachepot/serializer/pickle.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from cachepot.serializer import SerializerProtocol
 
+PICKLE_PROTOCOL = 4
+
 
 class PickleSerializer(SerializerProtocol[Any]):
     """Pickle-based serializer.
@@ -18,7 +20,7 @@ class PickleSerializer(SerializerProtocol[Any]):
     """
 
     def serialize(self, data: Any) -> bytes:
-        return pickle.dumps(data)
+        return pickle.dumps(data, protocol=PICKLE_PROTOCOL)
 
     def deserialize(self, serialized_data: bytes) -> Any:
         """Deserialize bytes produced by :meth:`serialize`.

--- a/tests/serializer/test_pickle.py
+++ b/tests/serializer/test_pickle.py
@@ -1,6 +1,7 @@
+import pickle
 from dataclasses import dataclass
 
-from cachepot.serializer.pickle import PickleSerializer
+from cachepot.serializer.pickle import PICKLE_PROTOCOL, PickleSerializer
 
 
 @dataclass
@@ -24,3 +25,12 @@ def test_pickle_serializer() -> None:
         serialized = serializer.serialize(original)
         deserialized = serializer.deserialize(serialized)
         assert deserialized == original
+
+
+def test_pickle_serializer_uses_stable_protocol() -> None:
+    serializer = PickleSerializer()
+
+    assert serializer.serialize("key") == pickle.dumps(
+        "key",
+        protocol=PICKLE_PROTOCOL,
+    )


### PR DESCRIPTION
## Summary
- Serialize pickle data with an explicit protocol instead of relying on Python's default.
- Keep the selected protocol aligned with the current default bytes to preserve existing cache entries.
- Add a regression test for the explicit protocol choice.

## Test plan
- `uv run ruff format --check cachepot/serializer/pickle.py tests/serializer/test_pickle.py`
- `uv run poe check`
- `uv run poe test`