### PR TITLE
fix: use RLock to allow nested proxy calls on the same CacheStore

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -60,7 +60,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         self.value_serializer = value_serializer
         self.backend = backend
         self.default_expire_seconds = default_expire_seconds
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def __get_real_key(self, key: T) -> bytes:
         serialized_key = self.key_serializer.serialize(key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -116,6 +116,34 @@ def test_proxy_no_double_execution_under_concurrency() -> None:
         assert results == [42] * 8
 
 
+def _returns_seven() -> int:
+    return 7
+
+
+def test_proxy_nested_same_store_does_not_deadlock() -> None:
+    """A proxy whose original function calls another proxy on the same store
+    must not deadlock.  Previously this failed because the store used a
+    non-reentrant Lock and the inner proxy tried to re-acquire it from the
+    same thread while the outer one held it.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        inner_proxied = store.proxy(_returns_seven)
+
+        def outer() -> int:
+            return inner_proxied(cache_key="inner-key") + 1
+
+        outer_proxied = store.proxy(outer)
+        assert outer_proxied(cache_key="outer-key") == 8
+        assert outer_proxied(cache_key="outer-key") == 8
+
+
 def test_proxy_requires_cache_key_at_runtime() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         cachestore = CacheStore(


### PR DESCRIPTION
## Summary

`CacheStore.__load_or_compute()` held a non-reentrant `threading.Lock` while calling `original_function`. When a proxied function itself called another proxy backed by the **same** store, the inner call attempted to re-acquire the lock already held by the outer call on the same thread — causing a permanent deadlock.

Replace `threading.Lock()` with `threading.RLock()` (reentrant lock) so the same thread can re-enter the lock for nested proxy calls.

### Changes

- `cachepot/store/__init__.py`: `self._lock = threading.Lock()` → `threading.RLock()`
- `tests/test_store.py`: add `test_proxy_nested_same_store_does_not_deadlock` regression test

## Test plan

- [x] Existing test suite passes (`uv run poe test`)
- [x] New regression test `test_proxy_nested_same_store_does_not_deadlock` verifies the fix
- [x] Lint and type-check pass (`uv run poe check`)