### PR TITLE
Add SQLite backend close support

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -2,6 +2,7 @@ import pathlib
 import sqlite3
 import threading
 from datetime import datetime
+from types import TracebackType
 from typing import cast
 
 from cachepot.backend import CacheBackendProtocol
@@ -36,6 +37,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
                   )""",
         )
         self.conn = conn
+
+    def close(self) -> None:
+        with self._lock:
+            self.conn.close()
+
+    def __enter__(self) -> "SQLiteCacheBackend":
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def save(
         self,

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -1,7 +1,10 @@
 import concurrent.futures
 import pathlib
+import sqlite3
 import tempfile
 import time
+
+import pytest
 
 from cachepot.backend.sqlite import SQLiteCacheBackend
 
@@ -22,6 +25,26 @@ def test_sqlite_connection() -> None:
         assert cachestore.load(b"3") == b"4"
         cachestore.delete(b"3")
         assert cachestore.load(b"3") is None
+
+
+def test_sqlite_close_closes_connection() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        cachestore.save(b"1", b"2", expire_seconds=1)
+        cachestore.close()
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            cachestore.load(b"1")
+
+
+def test_sqlite_context_manager_closes_connection() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        with SQLiteCacheBackend(f.name) as cachestore:
+            cachestore.save(b"1", b"2", expire_seconds=1)
+            assert cachestore.load(b"1") == b"2"
+
+        with pytest.raises(sqlite3.ProgrammingError):
+            cachestore.load(b"1")
 
 
 def test_expire() -> None:


### PR DESCRIPTION
## Summary
- Add `close()` to `SQLiteCacheBackend` so callers can explicitly release the held SQLite connection
- Add context manager support for deterministic cleanup with `with SQLiteCacheBackend(...)`
- Cover explicit close and context manager cleanup in SQLite backend tests

## Tests
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
