### PR TITLE
fix: use length-prefix encoding to prevent namespace key collisions

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -64,7 +64,8 @@ class CacheStore(CacheStoreProtocol[T, S]):
 
     def __get_real_key(self, key: T) -> bytes:
         serialized_key = self.key_serializer.serialize(key)
-        return self.namespace.encode() + b":" + serialized_key
+        ns_bytes = self.namespace.encode()
+        return len(ns_bytes).to_bytes(4, "big") + ns_bytes + serialized_key
 
     def get(self, key: T) -> S | None:
         real_key = self.__get_real_key(key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -144,6 +144,28 @@ def test_proxy_nested_same_store_does_not_deadlock() -> None:
         assert outer_proxied(cache_key="outer-key") == 8
 
 
+def test_namespace_key_no_collision() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store_a = CacheStore(
+            namespace="a",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        store_ab = CacheStore(
+            namespace="a:b",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        store_a.put("b:c", 1)
+        store_ab.put("c", 2)
+        assert store_a.get("b:c") == 1
+        assert store_ab.get("c") == 2
+
+
 def test_proxy_requires_cache_key_at_runtime() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         cachestore = CacheStore(


### PR DESCRIPTION
## Summary

- `CacheStore.__get_real_key` used `:` as separator between namespace and key bytes, allowing `("a", "b:c")` and `("a:b", "c")` to produce the same backend key
- Changed to length-prefix encoding: 4-byte big-endian namespace length + namespace bytes + serialized key
- This is collision-free for any namespace and key content, regardless of serializer

## Test plan

- [x] Added `test_namespace_key_no_collision` verifying the previously-colliding pair now resolves to distinct cache entries
- [x] All existing tests pass (25 passed)

## Trade-offs

Existing cache entries will be missed after this change (different key format). This is equivalent to a cold start and is acceptable for a correctness fix.
