### PR TITLE
feat: add has() to CacheStore to distinguish cache miss from stored None

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -24,6 +24,8 @@ class CacheProxyProtocol(Protocol[T, S_co]):
 class CacheStoreProtocol(Protocol[T, S]):
     def get(self, key: T) -> S | None: ...
 
+    def has(self, key: T) -> bool: ...
+
     def put(
         self,
         key: T,
@@ -73,6 +75,10 @@ class CacheStore(CacheStoreProtocol[T, S]):
         if loaded is None:
             return None
         return self.value_serializer.deserialize(loaded)
+
+    def has(self, key: T) -> bool:
+        real_key = self.__get_real_key(key)
+        return self.backend.load(real_key) is not None
 
     def put(
         self,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -45,6 +45,25 @@ def test_basis() -> None:
         assert cachestore.proxy(lambda: 3)(cache_key="y") == 3
 
 
+def test_has_distinguishes_miss_from_stored_none() -> None:
+    """has() returns False on miss and True on hit, even when the stored value
+    is None — a distinction that get() cannot express."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store: CacheStore[str, None] = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        assert not store.has("k")
+        store.put("k", None)
+        assert store.has("k")
+        assert store.get("k") is None
+        store.remove("k")
+        assert not store.has("k")
+
+
 def test_proxy_caches_none_return_value() -> None:
     """A function whose result is ``None`` must only be executed once
     per cached call, even though ``None`` is also the sentinel the


### PR DESCRIPTION
## Summary

`CacheStore.get()` returns `None` for both a cache miss and a stored `None` value, making the two cases indistinguishable to callers. This is a known limitation when the cached type `S` includes `None`.

This PR adds `has(key: T) -> bool` to `CacheStore` and `CacheStoreProtocol`. The method queries the backend directly, consistent with how `__load_or_compute` already bypasses `get()` to avoid the same ambiguity.

## Changes

- `cachepot/store/__init__.py`: add `has()` to `CacheStoreProtocol` and `CacheStore`
- `tests/test_store.py`: add `test_has_distinguishes_miss_from_stored_none` — verifies `has()` returns `True` for a stored `None` and `False` after removal

## Verification

- All 30 tests pass (`uv run poe test`)
- `ruff check` and `mypy` clean (`uv run poe check`)

## Trade-offs

`has()` + `get()` is two backend reads, which introduces a narrow TOCTOU window (an entry can expire between the two calls). For typical cache usage where entries live for seconds to minutes, this is not a practical concern. The alternative — changing `get()`'s return type to a sentinel — would be a breaking API change.
