### PR TITLE
fix: unify API surface naming and add lightweight exists() to backends

### DIFF
--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from cachepot.expire import ExpireSeconds
+from cachepot.expire import Expiry
 
 
 class CacheBackendProtocol(Protocol):
@@ -9,10 +9,12 @@ class CacheBackendProtocol(Protocol):
         key: bytes,
         value: bytes,
         *,
-        expire_seconds: ExpireSeconds,
+        expire_seconds: Expiry,
     ) -> None: ...
 
     def load(self, key: bytes) -> bytes | None: ...
+
+    def exists(self, key: bytes) -> bool: ...
 
     def delete(self, key: bytes) -> None: ...
 

--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import BinaryIO, cast
 
 from cachepot.backend import CacheBackendProtocol
-from cachepot.expire import ExpireSeconds, to_timedelta
+from cachepot.expire import Expiry, to_timedelta
 
 PathLike = pathlib.Path | str
 
@@ -30,7 +30,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         key: bytes,
         value: bytes,
         *,
-        expire_seconds: ExpireSeconds,
+        expire_seconds: Expiry,
     ) -> None:
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         expire_timestamp = time.mktime(expire_at.timetuple())
@@ -72,6 +72,10 @@ class FileSystemCacheBackend(CacheBackendProtocol):
 
     def __is_expired(self, path: pathlib.Path) -> bool:
         return path.stat().st_mtime < time.mktime(datetime.now().timetuple())
+
+    def exists(self, key: bytes) -> bool:
+        path = self.__get_real_path(key)
+        return path.is_file() and not self.__is_expired(path)
 
     def delete(self, key: bytes) -> None:
         with contextlib.suppress(FileNotFoundError):

--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -3,7 +3,7 @@ from typing import cast
 from redis import Redis
 
 from cachepot.backend import CacheBackendProtocol
-from cachepot.expire import ExpireSeconds, to_timedelta
+from cachepot.expire import Expiry, to_timedelta
 
 
 class RedisCacheBackend(CacheBackendProtocol):
@@ -17,7 +17,7 @@ class RedisCacheBackend(CacheBackendProtocol):
         key: bytes,
         value: bytes,
         *,
-        expire_seconds: ExpireSeconds,
+        expire_seconds: Expiry,
     ) -> None:
         # ``SET key value EX seconds`` is a single Redis command, so the
         # value and its TTL land together. The previous pipeline form
@@ -26,6 +26,9 @@ class RedisCacheBackend(CacheBackendProtocol):
 
     def load(self, key: bytes) -> bytes | None:
         return cast(bytes, self.redis.get(key))
+
+    def exists(self, key: bytes) -> bool:
+        return bool(self.redis.exists(key))
 
     def delete(self, key: bytes) -> None:
         self.redis.delete(key)

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -6,7 +6,7 @@ from types import TracebackType
 from typing import cast
 
 from cachepot.backend import CacheBackendProtocol
-from cachepot.expire import ExpireSeconds, to_timedelta
+from cachepot.expire import Expiry, to_timedelta
 
 ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
@@ -58,7 +58,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
         key: bytes,
         value: bytes,
         *,
-        expire_seconds: ExpireSeconds,
+        expire_seconds: Expiry,
     ) -> None:
         with self._lock:
             expire_at = datetime.now() + to_timedelta(expire_seconds)
@@ -85,6 +85,19 @@ INSERT OR REPLACE INTO cachepot
         if result:
             return cast(bytes, result[0])
         return None
+
+    def exists(self, key: bytes) -> bool:
+        current_datetime = datetime.now()
+        with self._lock:
+            result = self.conn.execute(
+                """\
+        SELECT 1
+          FROM cachepot
+         WHERE key = ?
+           AND expire_at > ?""",
+                (key, current_datetime),
+            ).fetchone()
+        return result is not None
 
     def delete(self, key: bytes) -> None:
         with self._lock:

--- a/cachepot/expire.py
+++ b/cachepot/expire.py
@@ -1,16 +1,19 @@
 from datetime import timedelta
 
-ExpireSeconds = int | float | timedelta
+Expiry = int | float | timedelta
+
+# Backward-compatible alias
+ExpireSeconds = Expiry
 
 
-def _assert_non_negative(value: timedelta, original: ExpireSeconds) -> None:
+def _assert_non_negative(value: timedelta, original: Expiry) -> None:
     if value.total_seconds() < 0:
         raise ValueError(
             f"expire_seconds must be non-negative, got {original!r}",
         )
 
 
-def to_timedelta(expire_seconds: ExpireSeconds) -> timedelta:
+def to_timedelta(expire_seconds: Expiry) -> timedelta:
     if isinstance(expire_seconds, (int, float)):
         result = timedelta(seconds=expire_seconds)
     else:

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
 from cachepot.backend import CacheBackendProtocol
-from cachepot.expire import ExpireSeconds
+from cachepot.expire import Expiry
 from cachepot.serializer import SerializerProtocol
 
 T = TypeVar("T", contravariant=True)
@@ -16,7 +16,7 @@ class CacheProxyProtocol(Protocol[T, S_co]):
         self,
         *args: Any,
         cache_key: T,
-        expire_seconds: ExpireSeconds | None = None,
+        expire_seconds: Expiry | None = None,
         **kwargs: Any,
     ) -> S_co: ...
 
@@ -31,7 +31,7 @@ class CacheStoreProtocol(Protocol[T, S]):
         key: T,
         value: S,
         *,
-        expire_seconds: ExpireSeconds | None = None,
+        expire_seconds: Expiry | None = None,
     ) -> None: ...
 
     def proxy(
@@ -39,7 +39,7 @@ class CacheStoreProtocol(Protocol[T, S]):
         original_function: Callable[..., S],
     ) -> CacheProxyProtocol[T, S]: ...
 
-    def remove(self, key: T) -> None: ...
+    def delete(self, key: T) -> None: ...
 
     def delete_expired(self) -> int: ...
 
@@ -49,7 +49,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
     key_serializer: SerializerProtocol[T]
     value_serializer: SerializerProtocol[S]
     backend: CacheBackendProtocol
-    default_expire_seconds: ExpireSeconds
+    default_expire_seconds: Expiry
 
     def __init__(
         self,
@@ -57,7 +57,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         backend: CacheBackendProtocol,
         key_serializer: SerializerProtocol[T],
         value_serializer: SerializerProtocol[S],
-        default_expire_seconds: ExpireSeconds,
+        default_expire_seconds: Expiry,
     ) -> None:
         self.namespace = namespace
         self.key_serializer = key_serializer
@@ -80,14 +80,14 @@ class CacheStore(CacheStoreProtocol[T, S]):
 
     def has(self, key: T) -> bool:
         real_key = self.__get_real_key(key)
-        return self.backend.load(real_key) is not None
+        return self.backend.exists(real_key)
 
     def put(
         self,
         key: T,
         value: S,
         *,
-        expire_seconds: ExpireSeconds | None = None,
+        expire_seconds: Expiry | None = None,
     ) -> None:
         if expire_seconds is None:
             expire_seconds = self.default_expire_seconds
@@ -106,7 +106,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         def _proxy(
             *args: Any,
             cache_key: T,
-            expire_seconds: ExpireSeconds | None = None,
+            expire_seconds: Expiry | None = None,
             **kwargs: Any,
         ) -> S:
             return self.__load_or_compute(
@@ -123,7 +123,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         self,
         *,
         cache_key: T,
-        expire_seconds: ExpireSeconds | None,
+        expire_seconds: Expiry | None,
         original_function: Callable[..., S],
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
@@ -141,7 +141,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
             self.put(cache_key, result, expire_seconds=expire_seconds)
             return result
 
-    def remove(self, key: T) -> None:
+    def delete(self, key: T) -> None:
         real_key = self.__get_real_key(key)
         self.backend.delete(real_key)
 

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -47,7 +47,7 @@ def example_usage() -> None:
     cachestore = SimpleFileSystemCacheStore('example', directory='./tmp')
     cachestore.put('x', 1)
     assert cachestore.get('x') == 1
-    cachestore.remove('x')
+    cachestore.delete('x')
     assert cachestore.get('x') is None
     assert cachestore.proxy(lambda: 3)(cache_key='y') == 3
     assert cachestore.proxy(lambda: 3)(cache_key='y') == 3

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -164,3 +164,28 @@ def test_delete_expired() -> None:
         assert live_path.exists()
         assert cachestore.load(b"live") == b"value"
         assert cachestore.delete_expired() == 0
+
+
+def test_exists() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cachestore = FileSystemCacheBackend(pathlib.Path(tmpdir))
+        assert not cachestore.exists(b"k")
+        cachestore.save(b"k", b"v", expire_seconds=60)
+        assert cachestore.exists(b"k")
+        cachestore.delete(b"k")
+        assert not cachestore.exists(b"k")
+
+
+def test_exists_does_not_delete_expired_entry() -> None:
+    """exists() must be side-effect-free: calling it on an expired entry
+    must not delete the file from disk."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"expired"
+        cachestore.save(key, b"value", expire_seconds=60)
+        realpath = _cache_entry_path(cache_dir, key)
+        _mark_expired(realpath)
+
+        assert not cachestore.exists(key)
+        assert realpath.exists(), "exists() must not delete the file"

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -47,9 +47,28 @@ def test_save_sets_ttl_atomically() -> None:
         cachestore.delete(b"ttl-check")
 
 
+def test_exists() -> None:
+    r = redis.Redis(host="localhost", port=6379, db=0)
+    cachestore = RedisCacheBackend(r)
+    assert not cachestore.exists(b"exists-key")
+    cachestore.save(b"exists-key", b"v", expire_seconds=60)
+    assert cachestore.exists(b"exists-key")
+    cachestore.delete(b"exists-key")
+    assert not cachestore.exists(b"exists-key")
+
+
+def test_exists_does_not_return_true_for_expired() -> None:
+    r = redis.Redis(host="localhost", port=6379, db=0)
+    cachestore = RedisCacheBackend(r)
+    cachestore.save(b"exists-expire-key", b"v", expire_seconds=1)
+    assert cachestore.exists(b"exists-expire-key")
+    time.sleep(2)
+    assert not cachestore.exists(b"exists-expire-key")
+
+
 def test_save_accepts_timedelta_expire_seconds() -> None:
     """The backend should still honour ``timedelta`` inputs from
-    ``ExpireSeconds`` after the SET+EX consolidation."""
+    ``Expiry`` after the SET+EX consolidation."""
     r = redis.Redis(host="localhost", port=6379, db=0)
     cachestore = RedisCacheBackend(r)
     cachestore.save(b"td-key", b"v", expire_seconds=timedelta(seconds=30))

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -115,6 +115,25 @@ def test_save_expiration_starts_after_lock_acquisition(
         assert cachestore.load(b"delayed") == b"value"
 
 
+def test_exists() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        assert not cachestore.exists(b"k")
+        cachestore.save(b"k", b"v", expire_seconds=60)
+        assert cachestore.exists(b"k")
+        cachestore.delete(b"k")
+        assert not cachestore.exists(b"k")
+
+
+def test_exists_does_not_return_true_for_expired() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        cachestore.save(b"k", b"v", expire_seconds=1)
+        assert cachestore.exists(b"k")
+        time.sleep(2)
+        assert not cachestore.exists(b"k")
+
+
 def _thread_worker(cachestore: SQLiteCacheBackend, i: int) -> None:
     key = str(i).encode()
     cachestore.save(key, key, expire_seconds=10)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -34,7 +34,7 @@ def test_basis() -> None:
         )
         cachestore.put("x", 1)
         assert cachestore.get("x") == 1
-        cachestore.remove("x")
+        cachestore.delete("x")
         assert cachestore.get("x") is None
         assert cachestore.proxy(lambda: 3)(cache_key="y") == 3
         assert cachestore.proxy(lambda: 3)(cache_key="y") == 3
@@ -61,7 +61,7 @@ def test_has_distinguishes_miss_from_stored_none() -> None:
         store.put("k", None)
         assert store.has("k")
         assert store.get("k") is None
-        store.remove("k")
+        store.delete("k")
         assert not store.has("k")
 
 


### PR DESCRIPTION
## Summary

Three API surface inconsistencies identified in the public interface:

- `CacheStoreProtocol.remove()` and `CacheBackendProtocol.delete()` named the same operation differently
- `ExpireSeconds` type alias accepted `timedelta` despite the name implying integer seconds only
- `CacheStore.has()` called `backend.load()` internally, loading the full value just to check key existence

## Changes

**Naming unification** (`remove` → `delete` on the Store side)

`CacheStoreProtocol.remove()` and `CacheStore.remove()` are renamed to `delete()` to match the vocabulary already used by `CacheBackendProtocol.delete()`. Callers using `store.remove(key)` need to update to `store.delete(key)`.

**Type alias rename** (`ExpireSeconds` → `Expiry`)

`ExpireSeconds` is renamed to `Expiry` to accurately reflect that `timedelta` values (not only integer seconds) are accepted. `ExpireSeconds` is kept as a backward-compatible alias so existing import sites continue to work.

**Lightweight existence check** (`backend.exists()`)

`CacheBackendProtocol` gains a new `exists(key: bytes) -> bool` method. All three backends implement it without loading the value:

| Backend | Implementation |
|---------|---------------|
| Filesystem | `path.is_file() and not __is_expired(path)` — reads only mtime, no file content loaded; side-effect-free (does not delete expired entries) |
| SQLite | `SELECT 1 … WHERE expire_at > ?` — existence-only query, no value column fetched |
| Redis | `bool(self.redis.exists(key))` — uses the Redis `EXISTS` command |

`CacheStore.has()` now delegates to `backend.exists()` instead of `backend.load()`.

**Note on breaking changes**: `CacheStore.remove()` is removed (renamed to `delete()`). Third-party implementations of `CacheBackendProtocol` must add `exists()` to satisfy the protocol under static type checkers.

## Test plan

- Added `test_exists()` for all three backends (filesystem, sqlite, redis)
- Added `test_exists_does_not_delete_expired_entry()` for the filesystem backend, asserting that `exists()` on an expired entry leaves the file on disk
- Added `test_exists_does_not_return_true_for_expired()` for sqlite and redis backends
- All 40 tests pass (`uv run poe test`)
- `uv run poe check` (ruff + mypy) passes with no issues