### PR TITLE
fix: raise ValueError for negative expire_seconds uniformly across backends

### DIFF
--- a/cachepot/expire.py
+++ b/cachepot/expire.py
@@ -3,7 +3,17 @@ from datetime import timedelta
 ExpireSeconds = int | float | timedelta
 
 
+def _assert_non_negative(value: timedelta, original: ExpireSeconds) -> None:
+    if value.total_seconds() < 0:
+        raise ValueError(
+            f"expire_seconds must be non-negative, got {original!r}",
+        )
+
+
 def to_timedelta(expire_seconds: ExpireSeconds) -> timedelta:
     if isinstance(expire_seconds, (int, float)):
-        return timedelta(seconds=expire_seconds)
-    return expire_seconds
+        result = timedelta(seconds=expire_seconds)
+    else:
+        result = expire_seconds
+    _assert_non_negative(result, expire_seconds)
+    return result

--- a/tests/test_expire.py
+++ b/tests/test_expire.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 from cachepot.expire import to_timedelta
 
 
@@ -13,3 +15,22 @@ def test_to_timedelta_int() -> None:
 
 def test_to_timedelta_timedelta() -> None:
     assert to_timedelta(timedelta(days=5)) == timedelta(days=5)
+
+
+def test_to_timedelta_zero_is_valid() -> None:
+    assert to_timedelta(0) == timedelta(0)
+
+
+def test_to_timedelta_negative_int_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        to_timedelta(-1)
+
+
+def test_to_timedelta_negative_float_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        to_timedelta(-0.5)
+
+
+def test_to_timedelta_negative_timedelta_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        to_timedelta(timedelta(seconds=-60))


### PR DESCRIPTION
Previously, passing a negative value as `expire_seconds` produced inconsistent behavior across backends: `FileSystemCacheBackend` silently wrote a file with a past mtime (immediately treated as expired on next read), `SQLiteCacheBackend` silently inserted a dead row that accumulated until `delete_expired()` was called, and `RedisCacheBackend` raised a `ValueError` from redis-py. There was no single, predictable contract.

This change centralises the validation in `cachepot/expire.py`. `to_timedelta()` now calls `_assert_non_negative()` after resolving the value, so a `ValueError` is raised immediately for any negative `int`, `float`, or `timedelta` regardless of which backend is in use. The error message includes the original value for easier debugging.

- All three input types (`int`, `float`, `timedelta`) are covered by the new guard.
- Zero is explicitly allowed and tested.
- Four new unit tests are added to `tests/test_expire.py` covering the zero, negative-int, negative-float, and negative-timedelta cases.
