### PR TITLE
Stabilize pickle output for set keys

### DIFF
--- a/cachepot/serializer/pickle.py
+++ b/cachepot/serializer/pickle.py
@@ -1,9 +1,71 @@
+import io
 import pickle
+from itertools import islice
 from typing import Any
 
 from cachepot.serializer import SerializerProtocol
 
 PICKLE_PROTOCOL = 4
+_PicklerBase: Any = pickle._Pickler  # type: ignore[attr-defined]
+
+
+class _DeterministicPickler(_PicklerBase):
+    dispatch = _PicklerBase.dispatch.copy()
+
+    @staticmethod
+    def _sorted_items(data: set[Any] | frozenset[Any]) -> list[Any]:
+        return sorted(data, key=_stable_pickle_sort_key)
+
+    def save_set(self, obj: set[Any]) -> None:  # noqa: C901
+        if self.proto < 4:
+            self.save_reduce(set, (self._sorted_items(obj),), obj=obj)
+            return
+
+        self.write(pickle.EMPTY_SET)
+        self.memoize(obj)
+
+        items = iter(self._sorted_items(obj))
+        while True:
+            batch = list(islice(items, self._BATCHSIZE))
+            if batch:
+                self.write(pickle.MARK)
+                for item in batch:
+                    self.save(item)
+                self.write(pickle.ADDITEMS)
+            if len(batch) < self._BATCHSIZE:
+                return
+
+    def save_frozenset(self, obj: frozenset[Any]) -> None:  # noqa: C901
+        if self.proto < 4:
+            self.save_reduce(frozenset, (self._sorted_items(obj),), obj=obj)
+            return
+
+        self.write(pickle.MARK)
+        for item in self._sorted_items(obj):
+            self.save(item)
+
+        if id(obj) in self.memo:
+            self.write(pickle.POP_MARK + self.get(self.memo[id(obj)][0]))
+            return
+
+        self.write(pickle.FROZENSET)
+        self.memoize(obj)
+
+
+_DeterministicPickler.dispatch[set] = _DeterministicPickler.save_set
+_DeterministicPickler.dispatch[frozenset] = (
+    _DeterministicPickler.save_frozenset
+)
+
+
+def _stable_pickle_sort_key(data: Any) -> bytes:
+    return _pickle_dumps(data)
+
+
+def _pickle_dumps(data: Any) -> bytes:
+    stream = io.BytesIO()
+    _DeterministicPickler(stream, protocol=PICKLE_PROTOCOL).dump(data)
+    return stream.getvalue()
 
 
 class PickleSerializer(SerializerProtocol[Any]):
@@ -20,7 +82,7 @@ class PickleSerializer(SerializerProtocol[Any]):
     """
 
     def serialize(self, data: Any) -> bytes:
-        return pickle.dumps(data, protocol=PICKLE_PROTOCOL)
+        return _pickle_dumps(data)
 
     def deserialize(self, serialized_data: bytes) -> Any:
         """Deserialize bytes produced by :meth:`serialize`.

--- a/tests/serializer/test_pickle.py
+++ b/tests/serializer/test_pickle.py
@@ -1,4 +1,7 @@
+import os
 import pickle
+import subprocess
+import sys
 from dataclasses import dataclass
 
 from cachepot.serializer.pickle import PICKLE_PROTOCOL, PickleSerializer
@@ -34,3 +37,33 @@ def test_pickle_serializer_uses_stable_protocol() -> None:
         "key",
         protocol=PICKLE_PROTOCOL,
     )
+
+
+def test_pickle_serializer_stabilizes_hash_randomized_sets() -> None:
+    first = _serialize_frozenset_with_hash_seed("1")
+    second = _serialize_frozenset_with_hash_seed("2")
+
+    assert first == second
+    assert PickleSerializer().deserialize(first) == frozenset(
+        {"alpha", "bravo", "charlie"},
+    )
+
+
+def _serialize_frozenset_with_hash_seed(seed: str) -> bytes:
+    code = """
+from cachepot.serializer.pickle import PickleSerializer
+
+print(
+    PickleSerializer()
+    .serialize(frozenset({"alpha", "bravo", "charlie"}))
+    .hex()
+)
+"""
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = seed
+    output = subprocess.check_output(  # noqa: S603
+        [sys.executable, "-c", code],
+        env=env,
+        text=True,
+    )
+    return bytes.fromhex(output.strip())


### PR DESCRIPTION
## Summary
- serialize `set` and `frozenset` items in a stable order before pickling
- preserve pickle round-tripping while avoiding hash-seed-dependent bytes for set-like keys
- add a cross-`PYTHONHASHSEED` regression test for frozenset serialization

## Validation
- `uv run poe format`
- `uv run poe check`
- `uv run pytest tests/serializer/test_pickle.py`
- `docker compose -f docker-compose.test.yml up -d redis && uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
