### PR TITLE
Prevent filesystem cache cleanup from removing fresh saves

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import pathlib
 import tempfile
+import threading
 import time
 from datetime import datetime
 from typing import BinaryIO, cast
@@ -21,6 +22,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             self.path = pathlib.Path(path)
         else:
             self.path = path
+        self.__lock = threading.RLock()
 
     def __get_real_path(self, key: bytes) -> pathlib.Path:
         return self.path / hashlib.sha256(key).hexdigest()
@@ -35,28 +37,29 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         expire_at = datetime.now() + to_timedelta(expire_seconds)
         expire_timestamp = time.mktime(expire_at.timetuple())
 
-        realpath = self.__get_real_path(key)
-        realpath.parent.mkdir(parents=True, exist_ok=True)
+        with self.__lock:
+            realpath = self.__get_real_path(key)
+            realpath.parent.mkdir(parents=True, exist_ok=True)
 
-        # Atomic write: stage the payload in a sibling temp file, stamp
-        # its mtime to the expiration time, then ``os.replace`` it onto
-        # the final path. A crash before the rename leaves the temp file
-        # behind but never exposes a partial or stale-mtime cache entry
-        # at the real path.
-        fd, tmpname = tempfile.mkstemp(
-            prefix=".tmp-",
-            dir=str(realpath.parent),
-        )
-        tmppath = pathlib.Path(tmpname)
-        try:
-            with cast(BinaryIO, os.fdopen(fd, "wb")) as f:
-                f.write(value)
-            os.utime(str(tmppath), (expire_timestamp, expire_timestamp))
-            tmppath.replace(realpath)
-        except BaseException:
-            with contextlib.suppress(FileNotFoundError):
-                tmppath.unlink()
-            raise
+            # Atomic write: stage the payload in a sibling temp file, stamp
+            # its mtime to the expiration time, then ``os.replace`` it onto
+            # the final path. A crash before the rename leaves the temp file
+            # behind but never exposes a partial or stale-mtime cache entry
+            # at the real path.
+            fd, tmpname = tempfile.mkstemp(
+                prefix=".tmp-",
+                dir=str(realpath.parent),
+            )
+            tmppath = pathlib.Path(tmpname)
+            try:
+                with cast(BinaryIO, os.fdopen(fd, "wb")) as f:
+                    f.write(value)
+                os.utime(str(tmppath), (expire_timestamp, expire_timestamp))
+                tmppath.replace(realpath)
+            except BaseException:
+                with contextlib.suppress(FileNotFoundError):
+                    tmppath.unlink()
+                raise
 
     def load(self, key: bytes) -> bytes | None:
         path = self.__get_real_path(key)
@@ -75,10 +78,11 @@ class FileSystemCacheBackend(CacheBackendProtocol):
 
     def exists(self, key: bytes) -> bool:
         path = self.__get_real_path(key)
-        return path.is_file() and not self.__is_expired(path)
+        with self.__lock:
+            return path.is_file() and not self.__is_expired(path)
 
     def delete(self, key: bytes) -> None:
-        with contextlib.suppress(FileNotFoundError):
+        with self.__lock, contextlib.suppress(FileNotFoundError):
             self.__get_real_path(key).unlink()
 
     def delete_expired(self) -> int:
@@ -96,7 +100,8 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         return False
 
     def __delete_if_expired(self, path: pathlib.Path) -> bool:
-        if self.__is_expired(path):
-            path.unlink()
-            return True
+        with self.__lock:
+            if self.__is_expired(path):
+                path.unlink()
+                return True
         return False

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -2,8 +2,10 @@ import hashlib
 import os
 import pathlib
 import tempfile
+import threading
 import time
 from datetime import datetime
+from types import MethodType
 from typing import BinaryIO, TextIO, cast
 
 import pytest
@@ -12,6 +14,7 @@ from cachepot.backend.filesystem import FileSystemCacheBackend
 from cachepot.expire import to_timedelta
 
 _ORIGINAL_PATH_OPEN = pathlib.Path.open
+_ORIGINAL_PATH_UNLINK = pathlib.Path.unlink
 
 
 def _cache_entry_path(cache_dir: pathlib.Path, key: bytes) -> pathlib.Path:
@@ -43,6 +46,80 @@ def _unlink_before_open(
             newline=newline,
         ),
     )
+
+
+class _UnlinkAfterConcurrentSave:
+    __slots__ = ("realpath", "save_done", "unlink_started")
+
+    def __init__(
+        self,
+        realpath: pathlib.Path,
+        unlink_started: threading.Event,
+        save_done: threading.Event,
+    ) -> None:
+        self.realpath = realpath
+        self.unlink_started = unlink_started
+        self.save_done = save_done
+
+    def __get__(
+        self,
+        obj: pathlib.Path,
+        _objtype: type[pathlib.Path] | None = None,
+    ) -> MethodType:
+        return MethodType(self, obj)
+
+    def __call__(
+        self,
+        path: pathlib.Path,
+        missing_ok: bool = False,
+    ) -> None:
+        if path == self.realpath:
+            self.unlink_started.set()
+            self.save_done.wait(timeout=0.2)
+        _ORIGINAL_PATH_UNLINK(path, missing_ok=missing_ok)
+
+
+def _save_after_unlink_starts(
+    cachestore: FileSystemCacheBackend,
+    key: bytes,
+    unlink_started: threading.Event,
+    save_done: threading.Event,
+) -> None:
+    assert unlink_started.wait(timeout=1)
+    cachestore.save(key, b"new", expire_seconds=3600)
+    save_done.set()
+
+
+def test_delete_expired_does_not_remove_concurrent_fresh_save(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"race"
+        cachestore.save(key, b"old", expire_seconds=60)
+        realpath = _cache_entry_path(cache_dir, key)
+        _mark_expired(realpath)
+        unlink_started = threading.Event()
+        save_done = threading.Event()
+
+        monkeypatch.setattr(
+            pathlib.Path,
+            "unlink",
+            _UnlinkAfterConcurrentSave(realpath, unlink_started, save_done),
+        )
+
+        writer = threading.Thread(
+            target=_save_after_unlink_starts,
+            args=(cachestore, key, unlink_started, save_done),
+        )
+        writer.start()
+        deleted = cachestore.delete_expired()
+        writer.join(timeout=1)
+
+        assert not writer.is_alive()
+        assert deleted == 1
+        assert cachestore.load(key) == b"new"
 
 
 def test_various_pathlike() -> None:
@@ -126,9 +203,7 @@ def test_save_sets_expiration_mtime_on_overwrite() -> None:
         cachestore.save(b"k", b"new", expire_seconds=3600)
 
         (entry,) = [p for p in cache_dir.iterdir() if p.is_file()]
-        future_threshold = (
-            datetime.now() + to_timedelta(60)
-        ).timestamp()
+        future_threshold = (datetime.now() + to_timedelta(60)).timestamp()
         assert entry.stat().st_mtime >= future_threshold
         assert cachestore.load(b"k") == b"new"
 


### PR DESCRIPTION
## Summary
- Serialize filesystem cache writes with expiration-based deletion using an instance lock.
- Add a regression test for a fresh save racing with expired-entry cleanup.

## Tests
- `uv run poe check`
- `uv run pytest tests/backend/test_filesystem.py`
- `uv run pytest tests/backend/test_filesystem.py tests/backend/test_sqlite.py tests/serializer tests/test_expire.py tests/test_store.py`

## Notes
- `uv run poe test` was attempted, but the Redis backend tests require a Redis server on `localhost:6379`, which is not running in this environment.
