### PR TITLE
fix: return result and add context when cache write/read fails

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,4 +1,5 @@
 import threading
+import warnings
 from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
@@ -71,12 +72,21 @@ class CacheStore(CacheStoreProtocol[T, S]):
         ns_bytes = self.namespace.encode()
         return len(ns_bytes).to_bytes(4, "big") + ns_bytes + serialized_key
 
+    def _deserialize(self, loaded: bytes, key: T) -> S:
+        try:
+            return self.value_serializer.deserialize(loaded)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cache deserialization failed: "
+                f"namespace={self.namespace!r}, key={key!r}",
+            ) from exc
+
     def get(self, key: T) -> S | None:
         real_key = self.__get_real_key(key)
         loaded = self.backend.load(real_key)
         if loaded is None:
             return None
-        return self.value_serializer.deserialize(loaded)
+        return self._deserialize(loaded, key)
 
     def has(self, key: T) -> bool:
         real_key = self.__get_real_key(key)
@@ -135,11 +145,27 @@ class CacheStore(CacheStoreProtocol[T, S]):
         with self._lock:
             loaded = self.backend.load(real_key)
             if loaded is not None:
-                return self.value_serializer.deserialize(loaded)
+                return self._deserialize(loaded, cache_key)
 
             result = original_function(*args, **kwargs)
-            self.put(cache_key, result, expire_seconds=expire_seconds)
+            self._put_or_warn(cache_key, result, expire_seconds)
             return result
+
+    def _put_or_warn(
+        self,
+        cache_key: T,
+        result: S,
+        expire_seconds: Expiry | None,
+    ) -> None:
+        try:
+            self.put(cache_key, result, expire_seconds=expire_seconds)
+        except Exception as exc:
+            warnings.warn(
+                f"Cache write failed: "
+                f"namespace={self.namespace!r}, "
+                f"key={cache_key!r}: {exc}",
+                stacklevel=5,
+            )
 
     def delete(self, key: T) -> None:
         real_key = self.__get_real_key(key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -255,9 +255,11 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
 
     assert result == 99
     assert call_count == 1
-    assert len(caught) == 1
-    assert "Cache write failed" in str(caught[0].message)
-    assert "testing" in str(caught[0].message)
+    cache_write_warnings = [
+        warning for warning in caught if "Cache write failed" in str(warning.message)
+    ]
+    assert len(cache_write_warnings) == 1
+    assert "testing" in str(cache_write_warnings[0].message)
 
 
 def test_get_raises_with_key_context_on_deserialize_failure() -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,8 +2,10 @@ import concurrent.futures
 import functools
 import tempfile
 import time
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
 
 import pytest
 from typing_extensions import assert_type
@@ -219,3 +221,60 @@ def test_proxy_requires_cache_key_at_runtime() -> None:
         proxied = cachestore.proxy(lambda: 3)
         with pytest.raises(TypeError, match="cache_key"):
             proxied()  # type: ignore[call-arg]
+
+
+def test_proxy_returns_result_when_backend_write_fails() -> None:
+    """proxy() must return the computed result even when write fails.
+
+    A disk-full or DB error must not discard an already-executed result.
+    A warning is issued so callers can observe the failure.
+    """
+    backend = MagicMock()
+    backend.load.return_value = None
+    backend.save.side_effect = OSError("No space left on device")
+
+    store: CacheStore[str, int] = CacheStore(
+        namespace="testing",
+        key_serializer=StringSerializer(),
+        value_serializer=PickleSerializer(),
+        backend=backend,
+        default_expire_seconds=60,
+    )
+
+    call_count = 0
+
+    def expensive() -> int:
+        nonlocal call_count
+        call_count += 1
+        return 99
+
+    proxied = store.proxy(expensive)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = proxied(cache_key="k")
+
+    assert result == 99
+    assert call_count == 1
+    assert len(caught) == 1
+    assert "Cache write failed" in str(caught[0].message)
+    assert "testing" in str(caught[0].message)
+
+
+def test_get_raises_with_key_context_on_deserialize_failure() -> None:
+    """get() must include namespace/key in the error on corrupt data."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = CacheStore(
+            namespace="my-ns",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        # Write corrupted bytes directly via the backend
+        real_key = store._CacheStore__get_real_key("bad-key")  # type: ignore[attr-defined]
+        store.backend.save(real_key, b"\xff\xfe corrupted", expire_seconds=60)
+
+        with pytest.raises(RuntimeError, match="my-ns") as exc_info:
+            store.get("bad-key")
+        assert "bad-key" in str(exc_info.value)
+        assert exc_info.value.__cause__ is not None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -256,7 +256,9 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
     assert result == 99
     assert call_count == 1
     cache_write_warnings = [
-        warning for warning in caught if "Cache write failed" in str(warning.message)
+        warning
+        for warning in caught
+        if "Cache write failed" in str(warning.message)
     ]
     assert len(cache_write_warnings) == 1
     assert "testing" in str(cache_write_warnings[0].message)


### PR DESCRIPTION
Two error-path fixes for `CacheStore`:

## 1. Proxy: computed result lost on backend write failure

`__load_or_compute` called `put()` and then `return result`.  If `put()`
raised (disk full, DB error, serialisation failure), the exception propagated
and discarded an already-computed result.

Fix: wrap `put()` in a helper `_put_or_warn()` that catches the exception and
issues a `warnings.warn` instead of re-raising.  The caller receives the
computed value; the entry is simply not persisted this run.

## 2. `get` / `proxy` read path: deserialisation failure loses key context

When `deserialize()` raised, the exception propagated without indicating which
`namespace` and `key` were involved, making cache-corruption diagnosis harder.

Fix: `_deserialize()` wraps the call in `try/except` and re-raises as
`RuntimeError(...) from exc`, including `namespace=` and `key=` in the message.

## Trade-offs

- `_put_or_warn` uses `warnings.warn` rather than silently swallowing or
  re-raising, so callers that filter warnings can observe write failures without
  being broken.
- `RuntimeError` wrapping preserves the original exception as `__cause__` for
  full traceback context.
- Both helpers keep `McCabe complexity ≤ 2` per the project lint config.

## Tests added

- `test_proxy_returns_result_when_backend_write_fails`: mocks `save` to raise
  `OSError`; asserts result is returned and a warning is emitted.
- `test_get_raises_with_key_context_on_deserialize_failure`: writes corrupt
  bytes to the backend; asserts `RuntimeError` with `namespace` and `key` in
  the message, with `__cause__` set.