### PR TITLE
fix: fsync temp file before atomic rename in filesystem cache save

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -41,11 +41,13 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             realpath = self.__get_real_path(key)
             realpath.parent.mkdir(parents=True, exist_ok=True)
 
-            # Atomic write: stage the payload in a sibling temp file, stamp
-            # its mtime to the expiration time, then ``os.replace`` it onto
-            # the final path. A crash before the rename leaves the temp file
-            # behind but never exposes a partial or stale-mtime cache entry
-            # at the real path.
+            # Atomic write: stage the payload in a sibling temp file, fsync
+            # to disk, stamp its mtime to the expiration time, then
+            # ``os.replace`` it onto the final path. Fsyncing before the
+            # rename ensures the data reaches durable storage before the entry
+            # becomes visible at the real path. A crash before the rename
+            # leaves the temp file behind but never exposes a partial or
+            # stale-mtime cache entry at the real path.
             fd, tmpname = tempfile.mkstemp(
                 prefix=".tmp-",
                 dir=str(realpath.parent),
@@ -54,6 +56,8 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             try:
                 with cast(BinaryIO, os.fdopen(fd, "wb")) as f:
                     f.write(value)
+                    f.flush()
+                    os.fsync(f.fileno())
                 os.utime(str(tmppath), (expire_timestamp, expire_timestamp))
                 tmppath.replace(realpath)
             except BaseException:


### PR DESCRIPTION
## What

Add `f.flush()` + `os.fsync(f.fileno())` to `FileSystemCacheBackend.save()` before the atomic rename, ensuring the payload reaches durable storage before the entry becomes visible at the real path.

## Why

The existing code uses a temp-file + `os.replace()` pattern to prevent partial cache entries from being visible. However, without an explicit fsync, the kernel may buffer the written data in the page cache. On a system crash or power failure immediately after the rename, the directory entry would point to the real path but the file content might be 0 bytes or corrupted.

Because the design contract is "a file at the real path means a valid cache entry", a post-crash corrupt file causes a deserialization error on the next cache hit — not just a cache miss — which is harder for callers to handle.

The `f.flush()` drains Python's write buffer to the OS, and `os.fsync()` ensures the OS page cache is written to durable storage before `os.replace()` makes the file visible.

## Changes

- `cachepot/backend/filesystem.py`: add `f.flush()` and `os.fsync(f.fileno())` inside the temp-file write block, before the file is closed and renamed.
- Update the comment to document the fsync guarantee.