### PR TITLE
fix: raise TypeError at proxy() creation time for reserved parameter names

### DIFF
--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -34,4 +34,13 @@ class RedisCacheBackend(CacheBackendProtocol):
         self.redis.delete(key)
 
     def delete_expired(self) -> int:
+        """Return 0: Redis expires entries via server-side TTL automatically.
+
+        Redis does not expose an API to enumerate or count entries that have
+        already been evicted by their TTL.  This method is a no-op that
+        satisfies the ``CacheBackendProtocol`` contract; the actual expiry is
+        handled transparently by Redis.  Callers must not use the return value
+        of this method as a health or activity metric when using a Redis
+        backend — it will always be 0 regardless of how many entries expired.
+        """
         return 0

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import threading
 import warnings
 from collections.abc import Callable
@@ -42,7 +43,16 @@ class CacheStoreProtocol(Protocol[T, S]):
 
     def delete(self, key: T) -> None: ...
 
-    def delete_expired(self) -> int: ...
+    def delete_expired(self) -> int:
+        """Return the number of expired entries removed.
+
+        Implementations backed by a TTL-aware store (e.g. Redis) that expire
+        entries autonomously may always return 0 — the backend still enforces
+        TTLs, but cannot count entries that were evicted without an explicit
+        deletion call.  Do not rely on a non-zero return value from such
+        backends as a liveness signal.
+        """
+        ...
 
 
 class CacheStore(CacheStoreProtocol[T, S]):
@@ -109,7 +119,19 @@ class CacheStore(CacheStoreProtocol[T, S]):
             expire_seconds=expire_seconds,
         )
 
-    def proxy(
+    _RESERVED_PROXY_PARAMS: frozenset[str] = frozenset(
+        {"cache_key", "expire_seconds"},
+    )
+
+    @staticmethod
+    def _proxy_conflicts(fn: Callable[..., Any]) -> frozenset[str]:
+        try:
+            params = inspect.signature(fn).parameters.keys()
+            return CacheStore._RESERVED_PROXY_PARAMS & params
+        except (TypeError, ValueError):
+            return frozenset()
+
+    def _make_proxy(
         self,
         original_function: Callable[..., S],
     ) -> CacheProxyProtocol[T, S]:
@@ -128,6 +150,32 @@ class CacheStore(CacheStoreProtocol[T, S]):
             )
 
         return _proxy
+
+    def proxy(
+        self,
+        original_function: Callable[..., S],
+    ) -> CacheProxyProtocol[T, S]:
+        """Return a caching proxy for *original_function*.
+
+        The proxy injects ``cache_key`` and ``expire_seconds`` as its own
+        keyword-only arguments before forwarding the remaining ``**kwargs``
+        to *original_function*.  Therefore *original_function* must **not**
+        declare parameters named ``cache_key`` or ``expire_seconds``; if it
+        does, those arguments are silently captured by the proxy and never
+        reach the wrapped function, causing a ``TypeError`` at call time.
+
+        A ``TypeError`` is raised at proxy creation time when such a conflict
+        is detected, before any calls are made.
+        """
+        conflicts = self._proxy_conflicts(original_function)
+        if conflicts:
+            names = ", ".join(f"'{n}'" for n in sorted(conflicts))
+            raise TypeError(
+                f"proxy() cannot wrap a function whose parameter(s) "
+                f"({names}) share a name with proxy's reserved keyword "
+                f"arguments 'cache_key' and 'expire_seconds'.",
+            )
+        return self._make_proxy(original_function)
 
     def __load_or_compute(
         self,

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -264,6 +264,42 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
     assert "testing" in str(cache_write_warnings[0].message)
 
 
+def _make_store(tmpdir: str) -> CacheStore[str, str]:
+    return CacheStore(
+        namespace="testing",
+        key_serializer=StringSerializer(),
+        value_serializer=PickleSerializer(),
+        backend=FileSystemCacheBackend(tmpdir),
+        default_expire_seconds=60,
+    )
+
+
+def test_proxy_rejects_function_with_cache_key_param() -> None:
+    """proxy() raises TypeError at creation time when the wrapped function
+    has a parameter named 'cache_key', because the proxy captures it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = _make_store(tmpdir)
+
+        def fn(*, cache_key: str) -> str:
+            return cache_key
+
+        with pytest.raises(TypeError, match="cache_key"):
+            store.proxy(fn)
+
+
+def test_proxy_rejects_function_with_expire_seconds_param() -> None:
+    """proxy() raises TypeError at creation time when the wrapped function
+    has a parameter named 'expire_seconds', because the proxy captures it."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = _make_store(tmpdir)
+
+        def fn(*, expire_seconds: int) -> str:
+            return str(expire_seconds)
+
+        with pytest.raises(TypeError, match="expire_seconds"):
+            store.proxy(fn)
+
+
 def test_get_raises_with_key_context_on_deserialize_failure() -> None:
     """get() must include namespace/key in the error on corrupt data."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

`CacheStore.proxy()` injects `cache_key` and `expire_seconds` as its own
keyword-only arguments and forwards the remaining `**kwargs` to the wrapped
function. If the wrapped function declares either of those names, Python's
keyword-argument binding silently captures them in the proxy's own parameters
before they reach `**kwargs`, so the original function never sees those values
and raises a confusing `TypeError` from inside its own body.

This PR raises `TypeError` **at proxy creation time** — before any calls are
made — with a message that names the conflicting parameter(s) and explains the
restriction.

A second implicit behaviour is documented: `RedisCacheBackend.delete_expired()`
always returns `0` because Redis expires entries server-side via TTL and
provides no API to count autonomously evicted keys. The method satisfies the
`CacheBackendProtocol` contract but must not be used as a monitoring metric
when a Redis backend is in use. The docstring and the `CacheStoreProtocol`
docstring are updated to make this explicit.

## Changes

- `cachepot/store/__init__.py`
  - Add `_proxy_conflicts()` static method: uses `inspect.signature()` to
    detect reserved parameter names; returns an empty frozenset when the
    function has no inspectable signature (built-ins, C extensions).
  - Add `_make_proxy()` helper: extracted from `proxy()` to keep each method
    within the project's McCabe-complexity limit of 2.
  - `proxy()`: call `_proxy_conflicts()` first and raise `TypeError` when
    conflicts are found; otherwise delegate to `_make_proxy()`.
  - `CacheStoreProtocol.delete_expired()`: add docstring noting that
    TTL-based backends may always return 0.
- `cachepot/backend/redis.py`
  - `RedisCacheBackend.delete_expired()`: add docstring explaining the
    server-side TTL semantics and warning against using the return value as a
    health metric.
- `tests/test_store.py`
  - `test_proxy_rejects_function_with_cache_key_param()`: verifies TypeError
    is raised when the wrapped function has a `cache_key` parameter.
  - `test_proxy_rejects_function_with_expire_seconds_param()`: verifies
    TypeError is raised when the wrapped function has an `expire_seconds`
    parameter.

## Verification

- All 19 non-Redis tests pass (`pytest tests/test_store.py tests/test_expire.py`).
- `ruff check` and `mypy` pass with no new errors.
- The two new tests cover both reserved parameter names.

## Trade-offs

The check uses `inspect.signature()` and silently skips functions for which
no signature is available (built-ins, C extensions). Adding a proxy around
such a function without a detectable conflict still works as before.
