### PR TITLE
feat: expose concrete classes at top-level cachepot namespace

### DIFF
--- a/cachepot/__init__.py
+++ b/cachepot/__init__.py
@@ -6,8 +6,18 @@ from . import (
     store,
 )
 from ._version import __version__
+from .backend.filesystem import FileSystemCacheBackend
+from .backend.sqlite import SQLiteCacheBackend
+from .serializer.json import JSONSerializer
+from .serializer.pickle import PickleSerializer
+from .serializer.str import StringSerializer
 
 __all__ = [
+    "FileSystemCacheBackend",
+    "JSONSerializer",
+    "PickleSerializer",
+    "SQLiteCacheBackend",
+    "StringSerializer",
     "__version__",
     "backend",
     "expire",


### PR DESCRIPTION
## Summary

Concrete cache backend and serializer classes were only accessible via
3-level internal import paths (e.g. `cachepot.backend.filesystem`). This
exposed internal file layout as a public API contract, making future
reorganisation a breaking change for users.

This PR re-exports the concrete classes from `cachepot/__init__.py`:

- `FileSystemCacheBackend`
- `SQLiteCacheBackend`
- `JSONSerializer`
- `PickleSerializer`
- `StringSerializer`

`RedisCacheBackend` is deliberately excluded because `redis` is an
optional dependency (`pip install cachepot[redis]`); importing it
unconditionally at the top level would raise `ImportError` for users
who have not installed the extra.

## Trade-offs

- Backward compatible: existing deep import paths continue to work unchanged.
- `cachepot/__init__.py` now imports 5 additional names; import time
  may increase slightly (sub-millisecond for stdlib-only modules).

## Verification

- `ruff format cachepot`: no changes
- `ruff check cachepot tests`: all checks passed
- `mypy cachepot tests`: no issues (23 source files)
- `pytest`: 45 passed (6 Redis failures are pre-existing -- no Redis server in local env)