### PR TITLE
fix: close SQLite connection when schema init fails in __init__

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -11,31 +11,46 @@ from cachepot.expire import Expiry, to_timedelta
 ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
 
+def _init_schema(conn: sqlite3.Connection) -> None:
+    conn.text_factory = bytes
+    conn.execute(
+        """\
+CREATE TABLE IF NOT EXISTS cachepot
+           ( key BLOB PRIMARY KEY
+           , value BLOB
+           , expire_at timestamp
+           )""",
+    )
+    conn.execute(
+        """\
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
+                 ON cachepot
+                  ( key
+                  , expire_at
+                  )""",
+    )
+
+
+def _open_and_init(path: str | pathlib.Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path, check_same_thread=False)
+    try:
+        _init_schema(conn)
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
 class SQLiteCacheBackend(CacheBackendProtocol):
     conn: sqlite3.Connection
     _lock: threading.Lock
 
     def __init__(self, conn: ConnectionLike) -> None:
         if isinstance(conn, (str, pathlib.Path)):
-            conn = sqlite3.connect(conn, check_same_thread=False)
+            conn = _open_and_init(conn)
+        else:
+            _init_schema(conn)
         self._lock = threading.Lock()
-        conn.text_factory = bytes
-        conn.execute(
-            """\
-CREATE TABLE IF NOT EXISTS cachepot
-           ( key BLOB PRIMARY KEY
-           , value BLOB
-           , expire_at timestamp
-           )""",
-        )
-        conn.execute(
-            """\
-CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
-                 ON cachepot
-                  ( key
-                  , expire_at
-                  )""",
-        )
         self.conn = conn
 
     def close(self) -> None:

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -3,6 +3,7 @@ import pathlib
 import sqlite3
 import tempfile
 import time
+import unittest.mock
 from datetime import datetime, timedelta
 
 import pytest
@@ -152,3 +153,41 @@ def test_sqlite_thread_safe() -> None:
             futures = [executor.submit(worker, i) for i in range(32)]
         results = [fut.result() for fut in futures]
     assert results == [None] * 32
+
+
+def test_init_closes_internal_connection_on_execute_failure() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        db_path = f.name
+
+    spy_holder: list[unittest.mock.MagicMock] = []
+    real_connect = sqlite3.connect
+
+    def patched_connect(
+        path: object, **kwargs: object,
+    ) -> sqlite3.Connection:
+        real_conn = real_connect(path, **kwargs)  # type: ignore[call-overload]
+        spy = unittest.mock.MagicMock(wraps=real_conn)
+        spy.execute.side_effect = sqlite3.OperationalError("injected")
+        spy_holder.append(spy)
+        return spy
+
+    with (
+        unittest.mock.patch("sqlite3.connect", side_effect=patched_connect),
+        pytest.raises(sqlite3.OperationalError, match="injected"),
+    ):
+        SQLiteCacheBackend(db_path)
+
+    spy_holder[0].close.assert_called_once()
+
+
+def test_init_does_not_close_caller_connection_on_failure() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        real_conn = sqlite3.connect(f.name)
+        spy = unittest.mock.MagicMock(wraps=real_conn)
+        spy.execute.side_effect = sqlite3.OperationalError("injected")
+
+        with pytest.raises(sqlite3.OperationalError, match="injected"):
+            SQLiteCacheBackend(spy)
+
+        spy.close.assert_not_called()
+        real_conn.close()


### PR DESCRIPTION
## Summary

- `SQLiteCacheBackend.__init__` opened a new `sqlite3` connection when given a
  path (`str` or `pathlib.Path`), but if the subsequent schema `execute()` calls
  raised an exception the connection was never closed.
- Callers had no reference to the connection, so they could not close it either.
- In CPython this is usually harmless (reference counting closes it when the
  local goes out of scope), but in PyPy or when cyclic references exist the
  file lock / WAL journal can remain until GC runs.

## Changes

- Extract `_init_schema(conn)`: sets `text_factory` and runs the two `CREATE`
  statements. Shared by both the path-based and connection-based init paths.
- Extract `_open_and_init(path)`: calls `sqlite3.connect`, wraps `_init_schema`
  in `try/except`, closes the connection and re-raises on failure.
- `__init__` delegates to `_open_and_init` for path arguments and to
  `_init_schema` directly for an already-open `sqlite3.Connection`.
  A caller-supplied connection is never closed on failure (caller owns it).

## Test plan

- New test `test_init_closes_internal_connection_on_execute_failure`: patches
  `sqlite3.connect` to return a spy whose `execute` raises; asserts `close()`
  is called once on the spy.
- New test `test_init_does_not_close_caller_connection_on_failure`: passes a
  spy connection directly; asserts `close()` is *not* called.
- All 47 existing SQLite + other-backend tests continue to pass.
- `ruff check` and `mypy` report no new issues.