### PR TITLE
fix: encode cache expiry in file header instead of mtime

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -2,6 +2,7 @@ import contextlib
 import hashlib
 import os
 import pathlib
+import struct
 import tempfile
 import threading
 import time
@@ -12,6 +13,9 @@ from cachepot.backend import CacheBackendProtocol
 from cachepot.expire import Expiry, to_timedelta
 
 PathLike = pathlib.Path | str
+
+_EXPIRY_HEADER_FORMAT = ">d"
+_EXPIRY_HEADER_SIZE = struct.calcsize(_EXPIRY_HEADER_FORMAT)
 
 
 class FileSystemCacheBackend(CacheBackendProtocol):
@@ -41,13 +45,11 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             realpath = self.__get_real_path(key)
             realpath.parent.mkdir(parents=True, exist_ok=True)
 
-            # Atomic write: stage the payload in a sibling temp file, fsync
-            # to disk, stamp its mtime to the expiration time, then
-            # ``os.replace`` it onto the final path. Fsyncing before the
-            # rename ensures the data reaches durable storage before the entry
-            # becomes visible at the real path. A crash before the rename
-            # leaves the temp file behind but never exposes a partial or
-            # stale-mtime cache entry at the real path.
+            # Atomic write: stage [8-byte expiry header][payload] in a sibling
+            # temp file, fsync to disk, then ``os.replace`` it onto the real
+            # path.  The expiry timestamp is encoded in the file itself so that
+            # external mtime changes (touch, rsync, tar, etc.) cannot corrupt
+            # the expiry state.
             fd, tmpname = tempfile.mkstemp(
                 prefix=".tmp-",
                 dir=str(realpath.parent),
@@ -55,10 +57,12 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             tmppath = pathlib.Path(tmpname)
             try:
                 with cast(BinaryIO, os.fdopen(fd, "wb")) as f:
+                    f.write(
+                        struct.pack(_EXPIRY_HEADER_FORMAT, expire_timestamp),
+                    )
                     f.write(value)
                     f.flush()
                     os.fsync(f.fileno())
-                os.utime(str(tmppath), (expire_timestamp, expire_timestamp))
                 tmppath.replace(realpath)
             except BaseException:
                 with contextlib.suppress(FileNotFoundError):
@@ -71,14 +75,21 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             if not self.__can_load(path):
                 return None
             with cast(BinaryIO, path.open("rb")) as f:
+                f.seek(_EXPIRY_HEADER_SIZE)
                 return f.read()
         return None
 
     def __can_load(self, path: pathlib.Path) -> bool:
         return path.is_file() and not self.__delete_if_expired(path)
 
+    def __read_expire_timestamp(self, path: pathlib.Path) -> float:
+        with contextlib.suppress(OSError, struct.error), path.open("rb") as f:
+            raw = f.read(_EXPIRY_HEADER_SIZE)
+            return struct.unpack(_EXPIRY_HEADER_FORMAT, raw)[0]
+        return float("-inf")
+
     def __is_expired(self, path: pathlib.Path) -> bool:
-        return path.stat().st_mtime < time.time()
+        return self.__read_expire_timestamp(path) < time.time()
 
     def exists(self, key: bytes) -> bool:
         path = self.__get_real_path(key)

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -1,6 +1,6 @@
 import hashlib
-import os
 import pathlib
+import struct
 import tempfile
 import threading
 import time
@@ -32,9 +32,15 @@ def _cache_entry_path(cache_dir: pathlib.Path, key: bytes) -> pathlib.Path:
     return cache_dir / hashlib.sha256(key).hexdigest()
 
 
+_EXPIRY_HEADER_FORMAT = ">d"
+_EXPIRY_HEADER_SIZE = struct.calcsize(_EXPIRY_HEADER_FORMAT)
+
+
 def _mark_expired(path: pathlib.Path) -> None:
+    data = path.read_bytes()
     expired_at = time.time() - 60
-    os.utime(path, (expired_at, expired_at))
+    header = struct.pack(_EXPIRY_HEADER_FORMAT, expired_at)
+    path.write_bytes(header + data[_EXPIRY_HEADER_SIZE:])
 
 
 def _unlink_before_open(
@@ -231,9 +237,9 @@ def test_save_leaves_no_temp_files() -> None:
         assert all(not n.startswith(".tmp-") for n in names)
 
 
-def test_save_sets_expiration_mtime_on_overwrite() -> None:
-    """Overwriting an entry must end with the new expiration mtime, not
-    the kernel-default ``st_mtime`` of an in-flight write."""
+def test_save_sets_expiration_header_on_overwrite() -> None:
+    """Overwriting an entry must end with the new expiration header, not
+    an in-flight temporary timestamp."""
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_dir = pathlib.Path(tmpdir)
         cachestore = FileSystemCacheBackend(cache_dir)
@@ -244,7 +250,9 @@ def test_save_sets_expiration_mtime_on_overwrite() -> None:
 
         (entry,) = [p for p in cache_dir.iterdir() if p.is_file()]
         future_threshold = (datetime.now() + to_timedelta(60)).timestamp()
-        assert entry.stat().st_mtime >= future_threshold
+        raw_header = entry.read_bytes()[:_EXPIRY_HEADER_SIZE]
+        (expire_ts,) = struct.unpack(_EXPIRY_HEADER_FORMAT, raw_header)
+        assert expire_ts >= future_threshold
         assert cachestore.load(b"k") == b"new"
 
 

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -194,9 +194,12 @@ def test_fractional_expire_seconds_preserves_subsecond_timestamp(
         realpath = _cache_entry_path(cache_dir, key)
         expected_expire_at = now.timestamp() + expire_seconds
 
-        assert realpath.stat().st_mtime == pytest.approx(
-            expected_expire_at,
+        raw_header = realpath.read_bytes()[:_EXPIRY_HEADER_SIZE]
+        (stored_expire_at,) = struct.unpack(
+            _EXPIRY_HEADER_FORMAT,
+            raw_header,
         )
+        assert stored_expire_at == pytest.approx(expected_expire_at)
 
         monkeypatch.setattr(
             filesystem_backend.time,


### PR DESCRIPTION
## Summary

`FileSystemCacheBackend` encoded cache-entry validity in the file's `mtime`
via `os.utime()`.  Any external tool — `touch`, `rsync --times`, tar with
`--preserve-permissions`, or CI artifact-cache restorers that reset mtime —
can silently resurrect an already-expired entry or immediately expire a
valid one, with no signal to the caller.

## Change

Replace mtime-based expiry with an 8-byte big-endian `float64` header
prepended to every cache file:

- `save()` writes `struct.pack(">d", expire_timestamp)` before the payload
  and drops the `os.utime()` call.
- `load()` seeks past the 8-byte header before returning the payload.
- New private `__read_expire_timestamp()` reads only the header; returns
  `-inf` (treat as expired) on any I/O or format error, keeping
  `__is_expired()` complexity within project limits.

External mtime changes now have no effect on expiry decisions.

## Test changes

- `_mark_expired()` rewrites the header in-place instead of calling
  `os.utime()`.
- `test_save_sets_expiration_mtime_on_overwrite` renamed to
  `test_save_sets_expiration_header_on_overwrite`; asserts the header
  timestamp instead of `st_mtime`.

## Verification

- `make` / `uv run poe check` / `uv run poe format`: all pass.
- 44 non-Redis tests pass (Redis tests skipped; no Redis available locally).
- Adjacent static check: `ruff check` — 0 new findings.

## Trade-offs

- **Backward incompatibility**: existing cache files (written by the old
  format) will be misread — the first 8 bytes of the payload are
  interpreted as a likely-past timestamp, so those entries immediately
  appear expired and are evicted on first access.  Cache misses are safe
  (the function is re-executed), so this is a transparent warm-up penalty.
- **File size**: +8 bytes per entry.
- **Benefit**: expiry state is now self-contained in the file, portable
  across backup/restore pipelines, and consistent with the SQLite and Redis
  backends that store state server-side.
