### PR TITLE
fix: acquire store lock in get(), has(), put(), and delete()

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -92,15 +92,17 @@ class CacheStore(CacheStoreProtocol[T, S]):
             ) from exc
 
     def get(self, key: T) -> S | None:
-        real_key = self.__get_real_key(key)
-        loaded = self.backend.load(real_key)
-        if loaded is None:
-            return None
-        return self._deserialize(loaded, key)
+        with self._lock:
+            real_key = self.__get_real_key(key)
+            loaded = self.backend.load(real_key)
+            if loaded is None:
+                return None
+            return self._deserialize(loaded, key)
 
     def has(self, key: T) -> bool:
-        real_key = self.__get_real_key(key)
-        return self.backend.exists(real_key)
+        with self._lock:
+            real_key = self.__get_real_key(key)
+            return self.backend.exists(real_key)
 
     def put(
         self,
@@ -109,15 +111,16 @@ class CacheStore(CacheStoreProtocol[T, S]):
         *,
         expire_seconds: Expiry | None = None,
     ) -> None:
-        if expire_seconds is None:
-            expire_seconds = self.default_expire_seconds
-        real_key = self.__get_real_key(key)
-        serialized_value = self.value_serializer.serialize(value)
-        self.backend.save(
-            real_key,
-            serialized_value,
-            expire_seconds=expire_seconds,
-        )
+        with self._lock:
+            if expire_seconds is None:
+                expire_seconds = self.default_expire_seconds
+            real_key = self.__get_real_key(key)
+            serialized_value = self.value_serializer.serialize(value)
+            self.backend.save(
+                real_key,
+                serialized_value,
+                expire_seconds=expire_seconds,
+            )
 
     _RESERVED_PROXY_PARAMS: frozenset[str] = frozenset(
         {"cache_key", "expire_seconds"},
@@ -216,8 +219,9 @@ class CacheStore(CacheStoreProtocol[T, S]):
             )
 
     def delete(self, key: T) -> None:
-        real_key = self.__get_real_key(key)
-        self.backend.delete(real_key)
+        with self._lock:
+            real_key = self.__get_real_key(key)
+            self.backend.delete(real_key)
 
     def delete_expired(self) -> int:
         return self.backend.delete_expired()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -300,6 +300,33 @@ def test_proxy_rejects_function_with_expire_seconds_param() -> None:
             store.proxy(fn)
 
 
+def test_direct_put_get_is_thread_safe() -> None:
+    """Concurrent direct put()/get() calls must not corrupt the cache.
+
+    Multiple threads writing different integer values to the same key must
+    each receive a valid integer back from get(), never None or an exception,
+    proving that get() and put() are protected by the same store lock as
+    proxy() / __load_or_compute().
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store: CacheStore[str, int] = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+
+        def put_then_get(i: int) -> int | None:
+            store.put("shared", i)
+            return store.get("shared")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(put_then_get, range(8)))
+
+        assert all(isinstance(r, int) for r in results)
+
+
 def test_get_raises_with_key_context_on_deserialize_failure() -> None:
     """get() must include namespace/key in the error on corrupt data."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

`CacheStore` held `self._lock` only inside `__load_or_compute()` (the
path taken by `proxy()`), while the direct public methods `get()`,
`has()`, `put()`, and `delete()` ran without any lock.

This asymmetry means a thread calling `put()` directly while another
thread is inside `proxy()` / `__load_or_compute()` could write to the
backend outside the lock window, racing with the read-then-write
pattern inside `__load_or_compute()`.

## Changes

- `cachepot/store/__init__.py`: wrap `get()`, `has()`, `put()`, and
  `delete()` bodies with `with self._lock:`.  Since `self._lock` is a
  `threading.RLock`, re-entry from `_put_or_warn() -> put()` inside
  `__load_or_compute()` is safe.

- `tests/test_store.py`: add `test_direct_put_get_is_thread_safe()` —
  8 threads concurrently calling `put()` then `get()` on the same key;
  asserts every result is a valid integer (no `None` or exception).

## Verification

\`\`\`
uv run ruff format cachepot tests  # no changes
uv run ruff check cachepot tests   # all checks passed
uv run mypy cachepot tests         # no issues
uv run pytest tests/ --ignore=tests/backend/test_redis.py  # 45 passed
\`\`\`