### PR TITLE
Preserve SQLite connection text factory

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -12,7 +12,6 @@ ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
 
 def _init_schema(conn: sqlite3.Connection) -> None:
-    conn.text_factory = bytes
     conn.execute(
         """\
 CREATE TABLE IF NOT EXISTS cachepot

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -48,6 +48,19 @@ def test_sqlite_connection() -> None:
         assert cachestore.load(b"3") is None
 
 
+def test_sqlite_connection_text_factory_is_preserved() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE external (value TEXT)")
+    conn.execute("INSERT INTO external (value) VALUES (?)", ("alpha",))
+
+    cachestore = SQLiteCacheBackend(conn)
+    cachestore.save(b"key", b"value", expire_seconds=1)
+
+    assert conn.text_factory is str
+    assert conn.execute("SELECT value FROM external").fetchone() == ("alpha",)
+    assert cachestore.load(b"key") == b"value"
+
+
 def test_sqlite_close_closes_connection() -> None:
     with tempfile.NamedTemporaryFile() as f:
         cachestore = SQLiteCacheBackend(f.name)


### PR DESCRIPTION
## Summary
Preserve the `sqlite3.Connection` text factory when initializing `SQLiteCacheBackend`.

## Changes
- `cachepot/backend/sqlite.py`: stop changing `conn.text_factory` during schema initialization.
- `tests/backend/test_sqlite.py`: add a regression test for an existing connection that already has external `TEXT` data.

## Why
The backend should not change an existing connection's text decoding behavior. This keeps external `TEXT` tables returning `str` after the backend is initialized.

## Verification
- `git diff --check`
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run pytest tests/backend/test_sqlite.py`
