### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,31 @@ Of course you can define own backend.
 
 ## Development
 
-You can install requirements with uv.
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
 
-```shell
-$ uv sync
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
 ```
 
-### Test
+Once installed, the hooks run automatically:
 
-```shell
-$ uv run poe check  # lint and type check
-$ uv run poe test  # run tests
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
 ```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
 
 # LICENSE
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same checks that run in CI (`poe check` and `poe test`) also run locally on pre-commit and pre-push.
- CI workflows are left completely unchanged — GitHub Actions remains the authoritative quality gate.

## Changes

- `lefthook.yml`: configures a pre-commit job (`poe check`) and pre-push jobs (`poe check` + `poe test`); clears Git environment variables before each job so nested/sibling repositories are not affected.
- `README.md`: replaces the existing Development section with an expanded version that documents lefthook installation and the hooks that fire automatically.

## Verification

- `uv run poe check` passes locally (ruff + mypy, no issues).
- `uv run poe test` passes locally (56 tests, 0 failures).
- The pre-commit hook fired and passed during the commit step.
- The pre-push hook fired (check + test) and passed during the push step.

## Notes

- Requires `lefthook` on your `PATH` (`brew install lefthook` or see https://lefthook.dev/).
- No CI workflow was modified.
