### PR TITLE
docs: add community health files (CONTRIBUTING.md, issue templates, PR template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a bug in cachepot
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Minimal code to reproduce the problem:
+
+```python
+from cachepot...
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened (include any error messages or tracebacks).
+
+**Environment**
+- Python version:
+- cachepot version:
+- OS:
+- Backend used (filesystem, sqlite, redis, etc.):
+
+**Additional context**
+Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for cachepot
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+Describe the problem you are trying to solve or the improvement you would like to see.
+
+**Proposed solution**
+Describe the solution you have in mind (new serializer, backend, API change, etc.).
+
+**Alternatives considered**
+Any alternative approaches you have thought about.
+
+**Additional context**
+Any other context or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+## Changes
+
+<!-- List the specific changes made. -->
+
+## Testing
+
+- [ ] `uv run poe check` passes (lint, type check, format)
+- [ ] `uv run poe test` passes
+
+## Related issues
+
+<!-- Link related issues with "Closes #N" or "Refs #N". -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to cachepot
+
+Thank you for your interest in contributing to cachepot, a Python cache library with type hints.
+
+## Development Setup
+
+```bash
+git clone https://github.com/kitsuyui/cachepot.git
+cd cachepot
+uv sync
+lefthook install   # install pre-commit and pre-push hooks
+```
+
+The project uses [lefthook](https://lefthook.dev/) to run the same checks as CI locally.
+
+## Running Tests and Checks
+
+```bash
+uv run poe check   # lint, type check, format check
+uv run poe test    # run tests
+```
+
+Or let the hooks run automatically when you commit/push.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes. Keep each PR focused on one change.
+3. Ensure `uv run poe check` and `uv run poe test` pass.
+4. Open a pull request against `main` using the provided template.
+
+Commits should follow the `fix:`, `feat:`, `docs:`, `chore:` prefix convention.
+
+## Reporting Bugs
+
+Use the bug report issue template. Include your Python version, OS, and steps to reproduce.
+
+## Security Vulnerabilities
+
+See [SECURITY.md](SECURITY.md) for the disclosure process. Do not open a public issue with exploit details.
+
+## Code Style
+
+This project uses `ruff` for linting and formatting. Run `uv run poe check` to verify before submitting.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the BSD-3-Clause license.


### PR DESCRIPTION
## Summary

Add the standard community health files that were missing from the repository:

- `CONTRIBUTING.md` — development setup with `uv` and lefthook, test/lint commands (`uv run poe check`, `uv run poe test`), PR workflow, and a pointer to `SECURITY.md`.
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report template asking for Python version, cachepot version, OS, backend type, and a minimal reproduction.
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template.
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist covering `poe check` and `poe test`.

`SECURITY.md` already exists at the repository root and is referenced from `CONTRIBUTING.md`.

## Changes

- Added `CONTRIBUTING.md` with uv/lefthook setup, poe commands, commit prefix convention, and PR workflow.
- Added `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`.
- Added `.github/PULL_REQUEST_TEMPLATE.md` with a Python check checklist.

## Testing

No source code changes; markdown-only additions. Lefthook hooks and CI workflows are unaffected.