### PR TITLE
ci: migrate PyPI publishing to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,6 +21,7 @@ jobs:
   deploy:
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -41,13 +42,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Migrate PyPI and Test PyPI publishing from legacy API token authentication to
[Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (OIDC).

## What changed

- Added `id-token: write` permission to the `deploy` job (required for OIDC token minting)
- Removed `user: __token__` and `password: ${{ secrets.PYPI_API_TOKEN }}` from the PyPI publish step
- Removed `user: __token__` and `password: ${{ secrets.TEST_PYPI_API_TOKEN }}` from the Test PyPI publish step

## Why

Storing long-lived API tokens in GitHub Secrets introduces a secret-leak risk. With
Trusted Publishers, GitHub Actions mints a short-lived OIDC token per run, so no
persistent secret is stored. `pypa/gh-action-pypi-publish` uses the OIDC token
automatically when no `user`/`password` is provided.

## Prerequisite (manual step)

Before merging, the Trusted Publisher must be registered on PyPI and Test PyPI for
this repository. See https://docs.pypi.org/trusted-publishers/adding-a-publisher/

- **PyPI**: publisher `kitsuyui/cachepot`, workflow `pypi-publish.yml`, environment (none)
- **Test PyPI**: same, but on https://test.pypi.org
