### PR TITLE
ci: pin spellcheck workflow reference

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,4 +10,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@8019e658f4665c962d0a88eb38b3b6be418e7be8


### PR DESCRIPTION
Summary
- Pin the reusable Spellcheck workflow to a specific `kitsuyui/gh-actions-workflows` commit.
- Match the repository's existing pattern of using fixed refs for shared reusable workflows.

Verification
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `typos .github/workflows/spellcheck.yml`
- collateral check: clean
- `uv sync`
- `uv run poe check`
- `docker compose -f docker-compose.test.yml up -d redis && uv run poe test`
- `uv run poe coverage-xml`
- `uv build`

Notes
- Redis-backed tests require the local Redis service from `docker-compose.test.yml`, matching the CI service setup.
