### PR TITLE
ci: add CodeQL SAST workflow for Python security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan to catch newly discovered vulnerabilities
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['python']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds a GitHub CodeQL workflow to perform static security analysis (SAST) on Python source code.

## Background

cachepot is a Python caching library that handles:
- **Pickle serialization** (`cachepot/serializer/`) — unsafe deserialization is a known attack vector
- **External backends**: Redis, SQLite, filesystem — potential injection or path traversal risks
- **PyPI distribution** — security vulnerabilities affect downstream users

Currently, no SAST workflow exists. This PR adds CodeQL analysis to detect Python security patterns at PR time.

## What this PR does

Adds `.github/workflows/codeql.yml` that:
- Runs CodeQL Python analysis on push to `main`, on pull requests, and weekly (Monday 09:00 UTC)
- Scans for common Python vulnerability patterns (injection, unsafe deserialization, etc.)
- Reports findings to the GitHub Security tab

## Trade-offs

- **Pros**: Catches security anti-patterns at PR time; free for public repositories; results visible in GitHub Security tab
- **Cons**: Weekly scan adds minor compute cost; may surface false positives that need triaging
- The other security gaps in this repository (push protection, validity checks, branch protection) require admin action in GitHub Settings and are not addressed by this PR