### PR TITLE
ci: pin Redis service image in test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       redis:
-        image: redis
+        image: redis:8.6.3@sha256:25dbb04fc4d6d190eda327dab551631500b0f9ac8f9808e8e63b7fda1ddff196
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s


### PR DESCRIPTION
## Summary
- Pin the Redis service image used by the Python test workflow to a Redis 8.6.3 digest.
- Reuse the same pinned Redis image already used by the coverage workflow.
- Keep the workflow behavior unchanged while removing the floating `redis:latest` dependency.

## Verification
- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run ruff format --check cachepot`
- `uv run poe coverage-xml`

## Notes
- The Redis-backed coverage command was rerun after flushing stale data from an already-running Redis container; the rerun passed.
