### PR TITLE
fix: use per-key locks for proxy cache misses

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,6 +1,7 @@
 import inspect
 import threading
 import warnings
+import weakref
 from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
@@ -76,11 +77,26 @@ class CacheStore(CacheStoreProtocol[T, S]):
         self.backend = backend
         self.default_expire_seconds = default_expire_seconds
         self._lock = threading.RLock()
+        self._key_locks: weakref.WeakValueDictionary[bytes, Any] = (
+            weakref.WeakValueDictionary()
+        )
 
     def __get_real_key(self, key: T) -> bytes:
         serialized_key = self.key_serializer.serialize(key)
         ns_bytes = self.namespace.encode()
         return len(ns_bytes).to_bytes(4, "big") + ns_bytes + serialized_key
+
+    def _get_or_create_key_lock(self, real_key: bytes) -> Any:
+        lock = self._key_locks.get(real_key)
+        if lock is None:
+            lock = threading.RLock()
+            self._key_locks[real_key] = lock
+        return lock
+
+    def _real_key_and_lock(self, key: T) -> tuple[bytes, Any]:
+        with self._lock:
+            real_key = self.__get_real_key(key)
+            return real_key, self._get_or_create_key_lock(real_key)
 
     def _deserialize(self, loaded: bytes, key: T) -> S:
         try:
@@ -92,16 +108,16 @@ class CacheStore(CacheStoreProtocol[T, S]):
             ) from exc
 
     def get(self, key: T) -> S | None:
-        with self._lock:
-            real_key = self.__get_real_key(key)
+        real_key, key_lock = self._real_key_and_lock(key)
+        with key_lock, self._lock:
             loaded = self.backend.load(real_key)
             if loaded is None:
                 return None
             return self._deserialize(loaded, key)
 
     def has(self, key: T) -> bool:
-        with self._lock:
-            real_key = self.__get_real_key(key)
+        real_key, key_lock = self._real_key_and_lock(key)
+        with key_lock, self._lock:
             return self.backend.exists(real_key)
 
     def put(
@@ -111,10 +127,10 @@ class CacheStore(CacheStoreProtocol[T, S]):
         *,
         expire_seconds: Expiry | None = None,
     ) -> None:
-        with self._lock:
+        real_key, key_lock = self._real_key_and_lock(key)
+        with key_lock, self._lock:
             if expire_seconds is None:
                 expire_seconds = self.default_expire_seconds
-            real_key = self.__get_real_key(key)
             serialized_value = self.value_serializer.serialize(value)
             self.backend.save(
                 real_key,
@@ -192,11 +208,12 @@ class CacheStore(CacheStoreProtocol[T, S]):
         # Inspect the backend directly so a stored ``None`` value is
         # distinguishable from a cache miss (the backend returns ``None``
         # only when the key is absent; a stored value is always bytes).
-        real_key = self.__get_real_key(cache_key)
-        with self._lock:
-            loaded = self.backend.load(real_key)
-            if loaded is not None:
-                return self._deserialize(loaded, cache_key)
+        real_key, key_lock = self._real_key_and_lock(cache_key)
+        with key_lock:
+            with self._lock:
+                loaded = self.backend.load(real_key)
+                if loaded is not None:
+                    return self._deserialize(loaded, cache_key)
 
             result = original_function(*args, **kwargs)
             self._put_or_warn(cache_key, result, expire_seconds)
@@ -219,8 +236,8 @@ class CacheStore(CacheStoreProtocol[T, S]):
             )
 
     def delete(self, key: T) -> None:
-        with self._lock:
-            real_key = self.__get_real_key(key)
+        real_key, key_lock = self._real_key_and_lock(key)
+        with key_lock, self._lock:
             self.backend.delete(real_key)
 
     def delete_expired(self) -> int:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import functools
 import tempfile
+import threading
 import time
 import warnings
 from collections.abc import Callable
@@ -156,6 +157,60 @@ def test_proxy_no_double_execution_under_concurrency() -> None:
         results = _run_concurrent(proxied, 8)
         assert fn.call_count == 1
         assert results == [42] * 8
+
+
+def test_proxy_misses_for_different_keys_run_concurrently() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store: CacheStore[str, int] = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        barrier = threading.Barrier(2)
+
+        def slow(value: int) -> int:
+            barrier.wait(timeout=1)
+            return value
+
+        proxied = store.proxy(slow)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(proxied, 1, cache_key="key-a")
+            second = pool.submit(proxied, 2, cache_key="key-b")
+
+            assert first.result(timeout=1) == 1
+            assert second.result(timeout=1) == 2
+
+
+def test_proxy_miss_does_not_block_other_key_get() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store: CacheStore[str, int] = CacheStore(
+            namespace="testing",
+            key_serializer=StringSerializer(),
+            value_serializer=PickleSerializer(),
+            backend=FileSystemCacheBackend(tmpdir),
+            default_expire_seconds=60,
+        )
+        entered = threading.Event()
+        release = threading.Event()
+        store.put("ready-key", 7)
+
+        def slow() -> int:
+            entered.set()
+            release.wait(timeout=2)
+            return 42
+
+        proxied = store.proxy(slow)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            pending = pool.submit(proxied, cache_key="slow-key")
+            assert entered.wait(timeout=1)
+
+            immediate = pool.submit(store.get, "ready-key")
+            assert immediate.result(timeout=1) == 7
+
+            release.set()
+            assert pending.result(timeout=1) == 42
 
 
 def _returns_seven() -> int:


### PR DESCRIPTION
Summary

CacheStore now uses per-key reentrant locks around cache operations, proxy miss computation no longer holds the store-wide lock for unrelated keys, and tests cover different-key concurrency plus other-key get during a slow miss.

Verification

- uv run python -m setuptools_scm --force-write-version-files
- uv run poe check
- uv run pytest tests/test_store.py
- uv run ruff format --check cachepot
- docker compose -f docker-compose.test.yml up -d redis && uv run poe test
- uv run poe coverage-xml
- actionlint -color .github/workflows/*.yml
- uv build
- git diff --check
- git diff origin/main | python3 .../scripts/check-pr-collateral.py --title "fix: use per-key locks for proxy cache misses" --format md
- uv run ruff check cachepot tests
- typos cachepot/store/__init__.py tests/test_store.py
- foreground implement-validator-compatible gate

Notes

- The reusable GitHub happy-commit workflow runs only on PR.
- Spellcheck was approximated locally with `typos` on the changed files.
