### PR TITLE
fix: correct stacklevel in _put_or_warn from 5 to 4

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -215,7 +215,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
                 f"Cache write failed: "
                 f"namespace={self.namespace!r}, "
                 f"key={cache_key!r}: {exc}",
-                stacklevel=5,
+                stacklevel=4,
             )
 
     def delete(self, key: T) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -262,6 +262,10 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
     ]
     assert len(cache_write_warnings) == 1
     assert "testing" in str(cache_write_warnings[0].message)
+    # Warning must be attributed to the proxy call site (this file), not an
+    # internal frame — i.e. stacklevel must be exactly 4 (warn → _put_or_warn
+    # → __load_or_compute → _proxy → caller).
+    assert cache_write_warnings[0].filename == __file__
 
 
 def _make_store(tmpdir: str) -> CacheStore[str, str]:


### PR DESCRIPTION
## Summary

`CacheStore._put_or_warn` issues a `warnings.warn` with `stacklevel=5`, but
the proxy call chain is only four frames deep:

```
caller (user code)
  → _proxy                  (store/__init__.py)
    → __load_or_compute     (store/__init__.py)
      → _put_or_warn        (store/__init__.py)
        → warnings.warn     ← stacklevel=1
```

With `stacklevel=5` the warning is attributed to the frame *above* the
caller, which is typically the test runner or module level rather than
the actual proxy invocation line.  This makes it impossible to locate the
offending call site from the warning message alone.

**Change**: `stacklevel=5` → `stacklevel=4`.

## Verification

Added an assertion to `test_proxy_returns_result_when_backend_write_fails`
that checks `warning.filename == __file__`, confirming the warning is
attributed to the test file (the proxy call site) rather than an internal
frame.

All 56 tests pass.