### PR TITLE
fix: return None for unknown Redis expired cleanup count

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ $ pip install cachepot
 0
 ```
 
+`delete_expired()` returns the number of entries removed when the backend can
+observe that count.  Redis handles TTL expiry server-side, so its backend
+returns `None` when the deleted-entry count is unknown.
+
 > **Security note**: `PickleSerializer` uses Python's `pickle` module, which can
 > execute arbitrary code during deserialization. Only use it when the cache
 > backend storage is fully under your control and trusted. For untrusted

--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -2,6 +2,8 @@ from typing import Protocol
 
 from cachepot.expire import Expiry
 
+DeletedExpiredCount = int | None
+
 
 class CacheBackendProtocol(Protocol):
     def save(
@@ -18,4 +20,10 @@ class CacheBackendProtocol(Protocol):
 
     def delete(self, key: bytes) -> None: ...
 
-    def delete_expired(self) -> int: ...
+    def delete_expired(self) -> DeletedExpiredCount:
+        """Delete expired entries and return the deleted count when known.
+
+        Backends that delegate TTL eviction to the storage engine may return
+        ``None`` when the number of expired entries is not observable.
+        """
+        ...

--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from redis import Redis
 
-from cachepot.backend import CacheBackendProtocol
+from cachepot.backend import CacheBackendProtocol, DeletedExpiredCount
 from cachepot.expire import Expiry, to_timedelta
 
 
@@ -33,14 +33,13 @@ class RedisCacheBackend(CacheBackendProtocol):
     def delete(self, key: bytes) -> None:
         self.redis.delete(key)
 
-    def delete_expired(self) -> int:
-        """Return 0: Redis expires entries via server-side TTL automatically.
+    def delete_expired(self) -> DeletedExpiredCount:
+        """Return ``None`` because Redis expires entries server-side.
 
         Redis does not expose an API to enumerate or count entries that have
         already been evicted by their TTL.  This method is a no-op that
         satisfies the ``CacheBackendProtocol`` contract; the actual expiry is
-        handled transparently by Redis.  Callers must not use the return value
-        of this method as a health or activity metric when using a Redis
-        backend — it will always be 0 regardless of how many entries expired.
+        handled transparently by Redis.  Callers must treat ``None`` as an
+        unknown deleted-entry count, not as zero expired entries.
         """
-        return 0
+        return None

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from collections.abc import Callable
 from typing import Any, Protocol, TypeVar
 
-from cachepot.backend import CacheBackendProtocol
+from cachepot.backend import CacheBackendProtocol, DeletedExpiredCount
 from cachepot.expire import Expiry
 from cachepot.serializer import SerializerProtocol
 
@@ -43,14 +43,13 @@ class CacheStoreProtocol(Protocol[T, S]):
 
     def delete(self, key: T) -> None: ...
 
-    def delete_expired(self) -> int:
-        """Return the number of expired entries removed.
+    def delete_expired(self) -> DeletedExpiredCount:
+        """Delete expired entries and return the removed count when known.
 
-        Implementations backed by a TTL-aware store (e.g. Redis) that expire
-        entries autonomously may always return 0 — the backend still enforces
-        TTLs, but cannot count entries that were evicted without an explicit
-        deletion call.  Do not rely on a non-zero return value from such
-        backends as a liveness signal.
+        Implementations backed by a TTL-aware store (e.g. Redis) may expire
+        entries autonomously.  Such backends return ``None`` when the deleted
+        count is not observable.  Do not use this return value as a health or
+        activity metric unless the selected backend documents a count.
         """
         ...
 
@@ -223,5 +222,5 @@ class CacheStore(CacheStoreProtocol[T, S]):
             real_key = self.__get_real_key(key)
             self.backend.delete(real_key)
 
-    def delete_expired(self) -> int:
+    def delete_expired(self) -> DeletedExpiredCount:
         return self.backend.delete_expired()

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -29,7 +29,7 @@ def test_expire() -> None:
 def test_delete_expired_is_noop() -> None:
     r = redis.Redis(host="localhost", port=6379, db=0)
     cachestore = RedisCacheBackend(r)
-    assert cachestore.delete_expired() == 0
+    assert cachestore.delete_expired() is None
 
 
 def test_save_sets_ttl_atomically() -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     typed_store = cast(CacheStore[str, int], None)
     proxied_increment = typed_store.proxy(lambda value: value + 1)
     assert_type(proxied_increment(1, cache_key="key"), int)
-    assert_type(typed_store.delete_expired(), int)
+    assert_type(typed_store.delete_expired(), int | None)
 
 
 def test_basis() -> None:
@@ -85,6 +85,21 @@ def test_delete_expired() -> None:
         assert store.get("expired") is None
         assert store.get("live") == 2
         assert store.delete_expired() == 0
+
+
+def test_delete_expired_propagates_unknown_count() -> None:
+    backend = MagicMock()
+    backend.delete_expired.return_value = None
+
+    store: CacheStore[str, int] = CacheStore(
+        namespace="testing",
+        key_serializer=StringSerializer(),
+        value_serializer=PickleSerializer(),
+        backend=backend,
+        default_expire_seconds=60,
+    )
+
+    assert store.delete_expired() is None
 
 
 def test_proxy_caches_none_return_value() -> None:


### PR DESCRIPTION
## Summary
- Add a shared `DeletedExpiredCount` return type so backends can report either a deleted count or an unknown count.
- Return `None` from the Redis backend because Redis handles TTL expiry server-side and cannot report how many entries expired.
- Document the contract and update tests for Redis and `CacheStore` propagation.

## Trade-offs
- This widens the public `delete_expired()` return contract from `int` to `int | None`; callers that need an exact cleanup count must handle Redis unknown result explicitly.

## Verification
- `git diff --check`
- Pre-commit hooks ran `ruff check cachepot tests` and `mypy cachepot tests`.
- Pre-push hooks ran the full test suite, which passed.
