### PR TITLE
test: cover example cache stores

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,8 @@
+# Examples
+
+This directory contains small, importable usage examples for building concrete
+`CacheStore` classes from cachepot's serializers and backends.
+
+The examples are intentionally kept outside the `cachepot` package so they do
+not become part of the public library API. Tests import them as smoke coverage
+to keep the snippets working as the library evolves.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,6 @@ test = "pytest"
 coverage-xml = "pytest --cov=cachepot --doctest-modules --cov-report=xml"
 format = "ruff format cachepot"
 check = [
-    { cmd = "ruff check cachepot tests" },
-    { cmd = "mypy cachepot tests" },
+    { cmd = "ruff check cachepot example tests" },
+    { cmd = "mypy cachepot example tests" },
 ]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,27 @@
+from example import (
+    FileSystemJSONCacheStore,
+    SimpleFileSystemCacheStore,
+    example_usage,
+)
+
+
+def test_simple_filesystem_cache_store(tmp_path) -> None:
+    store = SimpleFileSystemCacheStore("testing", directory=str(tmp_path))
+
+    store.put("key", 1)
+
+    assert store.get("key") == 1
+
+
+def test_filesystem_json_cache_store(tmp_path) -> None:
+    store = FileSystemJSONCacheStore("testing", directory=str(tmp_path))
+
+    store.put("key", {"value": [1, 2, 3]})
+
+    assert store.get("key") == {"value": [1, 2, 3]}
+
+
+def test_example_usage_runs(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    example_usage()


### PR DESCRIPTION
## Summary
- Add an `example/README.md` that explains the example package's role and why it stays outside the public library API.
- Add smoke tests for the example cache store classes and `example_usage()`.
- Include `example` in the project's Ruff and mypy check commands so the examples stay covered by static validation.

## Verification
- `uv run poe format`
- `uv run pytest tests/test_example.py`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uv run ruff check example tests/test_example.py`
- `uv run mypy example tests/test_example.py`
- `git diff --check`
- `typos example/README.md tests/test_example.py pyproject.toml`
- `actionlint -color .github/workflows/*.yml`

Pre-publish gates already passed locally:
- `implement-validator: target publish gate overall: pass`
- `check-pr-collateral.py: no violations or advisories`
