### PR TITLE
docs: document proxy expiration defaults

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -20,7 +20,14 @@ class CacheProxyProtocol(Protocol[T, S_co]):
         cache_key: T,
         expire_seconds: Expiry | None = None,
         **kwargs: Any,
-    ) -> S_co: ...
+    ) -> S_co:
+        """Call the proxy using *cache_key* as the cache entry key.
+
+        Passing ``expire_seconds=None`` does not disable expiration.  It
+        lets the wrapped store use its ``default_expire_seconds`` value
+        when saving a cache miss.
+        """
+        ...
 
 
 class CacheStoreProtocol(Protocol[T, S]):
@@ -166,6 +173,11 @@ class CacheStore(CacheStoreProtocol[T, S]):
         declare parameters named ``cache_key`` or ``expire_seconds``; if it
         does, those arguments are silently captured by the proxy and never
         reach the wrapped function, causing a ``TypeError`` at call time.
+
+        Passing ``expire_seconds=None`` to the proxy does not disable
+        expiration; cache misses are stored with this store's
+        ``default_expire_seconds`` value, the same default used by
+        ``put()``.
 
         A ``TypeError`` is raised at proxy creation time when such a conflict
         is detected, before any calls are made.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -112,6 +112,24 @@ def test_proxy_caches_none_return_value() -> None:
         assert call_count == 1
 
 
+def test_proxy_expire_none_uses_store_default() -> None:
+    backend = MagicMock()
+    backend.load.return_value = None
+
+    store: CacheStore[str, int] = CacheStore(
+        namespace="testing",
+        key_serializer=StringSerializer(),
+        value_serializer=PickleSerializer(),
+        backend=backend,
+        default_expire_seconds=60,
+    )
+
+    proxied = store.proxy(lambda: 42)
+
+    assert proxied(cache_key="key", expire_seconds=None) == 42
+    assert backend.save.call_args.kwargs["expire_seconds"] == 60
+
+
 class _CountingFunction:
     def __init__(self) -> None:
         self.call_count = 0


### PR DESCRIPTION
## Summary
- Document that proxy calls with `expire_seconds=None` use the store's `default_expire_seconds` value instead of disabling expiration.
- Add regression coverage for the explicit `None` path so the proxy default stays tied to `CacheStore.put()` semantics.

## Verification
- `uv run poe format`
- `uv run pytest tests/test_store.py`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uv run ruff check cachepot/store/__init__.py tests/test_store.py`
- `uv run mypy cachepot tests`
- `typos cachepot/store/__init__.py tests/test_store.py`
- `actionlint -color .github/workflows/*.yml`
- `git diff --check`

Pre-publish gates already passed locally:
- `implement-validator: target publish gate overall: pass`
- `check-pr-collateral.py: no violations or advisories`
