### PR TITLE
fix: skip files without cachepot header in delete_expired() and load()

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -79,17 +79,22 @@ class FileSystemCacheBackend(CacheBackendProtocol):
                 return f.read()
         return None
 
-    def __can_load(self, path: pathlib.Path) -> bool:
-        return path.is_file() and not self.__delete_if_expired(path)
+    def __is_loadable(self, path: pathlib.Path) -> bool:
+        ts = self.__read_expire_timestamp(path)
+        return ts is not None and not self.__delete_if_expired(path)
 
-    def __read_expire_timestamp(self, path: pathlib.Path) -> float:
+    def __can_load(self, path: pathlib.Path) -> bool:
+        return path.is_file() and self.__is_loadable(path)
+
+    def __read_expire_timestamp(self, path: pathlib.Path) -> float | None:
         with contextlib.suppress(OSError, struct.error), path.open("rb") as f:
             raw = f.read(_EXPIRY_HEADER_SIZE)
             return struct.unpack(_EXPIRY_HEADER_FORMAT, raw)[0]
-        return float("-inf")
+        return None
 
     def __is_expired(self, path: pathlib.Path) -> bool:
-        return self.__read_expire_timestamp(path) < time.time()
+        ts = self.__read_expire_timestamp(path)
+        return ts is not None and ts < time.time()
 
     def exists(self, key: bytes) -> bool:
         path = self.__get_real_path(key)

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -302,6 +302,44 @@ def test_exists() -> None:
         assert not cachestore.exists(b"k")
 
 
+def test_delete_expired_skips_non_cachepot_file() -> None:
+    """delete_expired() must not remove files that lack the cachepot header."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        non_cache = cache_dir / "README"
+        non_cache.write_bytes(b"not a cachepot file")
+
+        assert cachestore.delete_expired() == 0
+        assert non_cache.exists()
+
+
+def test_delete_expired_skips_file_with_truncated_header() -> None:
+    """A file shorter than the 8-byte expiry header is not deleted."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        short_file = cache_dir / "too-short"
+        short_file.write_bytes(b"\x00\x01\x02")
+
+        assert cachestore.delete_expired() == 0
+        assert short_file.exists()
+
+
+def test_load_returns_none_for_truncated_header_file() -> None:
+    """load() must return None for a file at the key-derived path whose header
+    is too short to unpack (e.g. a partially written file)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"collision-key"
+        key_path = _cache_entry_path(cache_dir, key)
+        key_path.write_bytes(b"\x00\x01")  # shorter than the 8-byte header
+
+        assert cachestore.load(key) is None
+        assert key_path.exists()
+
+
 def test_exists_does_not_delete_expired_entry() -> None:
     """exists() must be side-effect-free: calling it on an expired entry
     must not delete the file from disk."""


### PR DESCRIPTION
## Problem

`FileSystemCacheBackend.delete_expired()` iterates every file in the cache directory and calls `__read_expire_timestamp()` on each one.  When the header cannot be read (`OSError` or `struct.error`), the method previously returned `float("-inf")`.  Because `float("-inf") < time.time()` is always true, every unreadable file was treated as expired and deleted with `path.unlink()`.

This caused silent data loss in two scenarios:

1. **Non-cachepot files** placed in the cache directory (`.gitkeep`, `README`, editor temp files) were deleted when `delete_expired()` was called.
2. **Files written before the 8-byte header format** (introduced in commit 92dbb54) had no expiry header; they were immediately "expired" on the first `delete_expired()` call with no warning.

## Fix

- `__read_expire_timestamp` now returns `float | None`, returning `None` on any parse failure instead of `float("-inf")`.
- `__is_expired` treats `None` as non-expired, so files whose headers cannot be parsed are left untouched by `delete_expired()`.
- A new private helper `__is_loadable` is extracted so that `load()` also skips files without a valid header at the key-derived path, returning `None` rather than serving truncated or corrupt data.

## Tests added

| test | what it verifies |
| --- | --- |
| `test_delete_expired_skips_non_cachepot_file` | `delete_expired()` leaves a plain file untouched |
| `test_delete_expired_skips_file_with_truncated_header` | `delete_expired()` leaves a 3-byte file untouched |
| `test_load_returns_none_for_truncated_header_file` | `load()` returns `None` and does not delete a 2-byte file at the key path |

## Scope

This fix addresses header-parse failures (files shorter than 8 bytes, or files that cannot be opened).  Files ≥ 8 bytes whose first bytes happen to decode as a past IEEE-754 double are out of scope; distinguishing those from genuine expired entries would require a magic-byte prefix or a separate naming convention, which is a structural change.