### PR TITLE
feat: track SQLite schema version with PRAGMA user_version

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -10,6 +10,19 @@ from cachepot.expire import Expiry, to_timedelta
 
 ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
+_SCHEMA_VERSION = 1
+
+
+def _migrate(conn: sqlite3.Connection, from_version: int) -> None:
+    if from_version > _SCHEMA_VERSION:
+        raise RuntimeError(
+            f"cachepot database schema version {from_version} is newer than "
+            f"the current library version ({_SCHEMA_VERSION}). "
+            "Upgrade cachepot to open this database.",
+        )
+    conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+    conn.commit()
+
 
 def _init_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
@@ -28,6 +41,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
                   , expire_at
                   )""",
     )
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    if version != _SCHEMA_VERSION:
+        _migrate(conn, version)
 
 
 def _open_and_init(path: str | pathlib.Path) -> sqlite3.Connection:

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -30,6 +30,55 @@ class _AdvancingLock:
         return None
 
 
+def test_schema_version_is_set_on_new_database() -> None:
+    """A freshly initialised database must have user_version = 1."""
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        conn = sqlite3.connect(f.name)
+        SQLiteCacheBackend(conn)
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 1
+        conn.close()
+
+
+def test_schema_version_upgrades_unversioned_database() -> None:
+    """An existing database with user_version = 0 is accepted and upgraded
+    to version 1 without requiring a data migration."""
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        # Simulate a pre-versioning database: create the schema manually,
+        # leave user_version at the SQLite default of 0.
+        conn = sqlite3.connect(f.name)
+        conn.execute(
+            "CREATE TABLE cachepot"
+            " (key BLOB PRIMARY KEY, value BLOB, expire_at timestamp)",
+        )
+        conn.commit()
+        conn.close()
+
+        # Opening with SQLiteCacheBackend must succeed and migrate
+        # user_version to 1.
+        with SQLiteCacheBackend(f.name) as backend:
+            backend.save(b"k", b"v", expire_seconds=60)
+            assert backend.load(b"k") == b"v"
+
+        conn2 = sqlite3.connect(f.name)
+        version = conn2.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 1
+        conn2.close()
+
+
+def test_schema_version_raises_on_future_schema() -> None:
+    """Opening a database whose user_version exceeds the current library
+    version must raise RuntimeError rather than silently misinterpreting it."""
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        conn = sqlite3.connect(f.name)
+        conn.execute("PRAGMA user_version = 999")
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(RuntimeError, match="schema version 999"):
+            SQLiteCacheBackend(f.name)
+
+
 def test_sqlite_connection() -> None:
     with tempfile.NamedTemporaryFile() as f:
         cachestore = SQLiteCacheBackend(pathlib.Path(f.name))


### PR DESCRIPTION
## Summary

Add schema version tracking to `SQLiteCacheBackend` using SQLite's
built-in `PRAGMA user_version`.

- Introduces `_SCHEMA_VERSION = 1` constant and `_migrate()` helper
- Every new or existing database is stamped with `user_version = 1` on
  first open
- A database whose `user_version` exceeds `_SCHEMA_VERSION` raises
  `RuntimeError` with a clear upgrade message, preventing silent schema
  drift when a newer database is opened with an older library version
- Version 0 (legacy, unversioned) databases are accepted and upgraded
  without requiring a data migration, since the table schema itself has
  not changed

## Tests

Three new tests in `tests/backend/test_sqlite.py`:
- `test_schema_version_is_set_on_new_database` — fresh DB gets version 1
- `test_schema_version_upgrades_unversioned_database` — legacy DB is
  opened, migrated, and remains functional
- `test_schema_version_raises_on_future_schema` — DB with version 999
  raises `RuntimeError` matching "schema version 999"