### PR TITLE
docs: document proxy cache-write failure as warning, not exception

### DIFF
--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -169,6 +169,19 @@ class CacheStore(CacheStoreProtocol[T, S]):
 
         A ``TypeError`` is raised at proxy creation time when such a conflict
         is detected, before any calls are made.
+
+        **Cache write failures are demoted to warnings.**  When the proxy
+        stores a computed result and the backend raises any exception,
+        the exception is caught and emitted via :func:`warnings.warn` instead
+        of propagating to the caller.  The original function's return value
+        is still returned normally.  This is intentional graceful degradation:
+        the proxy remains functional even when the backend is unavailable,
+        at the cost of recomputing the result on every call.
+
+        This differs from calling :meth:`put` directly, where backend
+        exceptions propagate unchanged to the caller.  If your application
+        must surface cache write errors as exceptions, call :meth:`put`
+        explicitly rather than using a proxy.
         """
         conflicts = self._proxy_conflicts(original_function)
         if conflicts:


### PR DESCRIPTION
## Summary

`CacheStore.proxy()` silently converts cache write failures into `warnings.warn()` calls rather than raising exceptions. This asymmetry with direct `put()` calls — which propagate exceptions — was undocumented, making it easy to miss that backend write errors can go unnoticed when using the proxy.

This PR adds a section to the `proxy()` docstring that:
- Explains that cache write failures are demoted to warnings (not exceptions)
- Contrasts this behavior with `put()`, which propagates exceptions unchanged
- Describes the graceful degradation intent: the proxy remains functional when the backend is unavailable

## Verification

- `uv run poe format` — no changes
- `uv run poe check` — clean (ruff + mypy)
- `uv run poe test` — 56 passed
- `vulture cachepot/` — only pre-existing false positives (public API methods)
- `check-pr-collateral.py` — clean
