### PR TITLE
ci: pin workflow action refs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,10 +24,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -39,11 +39,11 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Why
GitHub Actions tag and branch references can move. Pinning the workflow actions to commit SHAs makes the test and publishing jobs deterministic and reduces supply-chain risk, especially for the PyPI publishing workflow.

## What changed
- Pinned `actions/checkout` and `astral-sh/setup-uv` in `.github/workflows/python-test.yml`.
- Pinned `actions/checkout`, `astral-sh/setup-uv`, and `pypa/gh-action-pypi-publish` in `.github/workflows/pypi-publish.yml`.
- Kept the source tag or branch as an inline comment next to each pinned SHA.

## Verification
- `actionlint .github/workflows/python-test.yml .github/workflows/pypi-publish.yml`
- `uv run ruff format --check cachepot`
- `uv run poe check`
- `uv run poe test`
