### PR TITLE
fix: guard use-after-close in SQLiteCacheBackend

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -43,6 +43,7 @@ def _open_and_init(path: str | pathlib.Path) -> sqlite3.Connection:
 class SQLiteCacheBackend(CacheBackendProtocol):
     conn: sqlite3.Connection
     _lock: threading.Lock
+    _closed: bool
 
     def __init__(self, conn: ConnectionLike) -> None:
         if isinstance(conn, (str, pathlib.Path)):
@@ -51,10 +52,16 @@ class SQLiteCacheBackend(CacheBackendProtocol):
             _init_schema(conn)
         self._lock = threading.Lock()
         self.conn = conn
+        self._closed = False
 
     def close(self) -> None:
         with self._lock:
+            self._closed = True
             self.conn.close()
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("SQLiteCacheBackend is already closed")
 
     def __enter__(self) -> "SQLiteCacheBackend":
         return self
@@ -75,6 +82,7 @@ class SQLiteCacheBackend(CacheBackendProtocol):
         expire_seconds: Expiry,
     ) -> None:
         with self._lock:
+            self._check_open()
             expire_at = datetime.now() + to_timedelta(expire_seconds)
             self.conn.execute(
                 """\
@@ -88,6 +96,7 @@ INSERT OR REPLACE INTO cachepot
     def load(self, key: bytes) -> bytes | None:
         current_datetime = datetime.now()
         with self._lock:
+            self._check_open()
             result = self.conn.execute(
                 """\
         SELECT value
@@ -103,6 +112,7 @@ INSERT OR REPLACE INTO cachepot
     def exists(self, key: bytes) -> bool:
         current_datetime = datetime.now()
         with self._lock:
+            self._check_open()
             result = self.conn.execute(
                 """\
         SELECT 1
@@ -115,6 +125,7 @@ INSERT OR REPLACE INTO cachepot
 
     def delete(self, key: bytes) -> None:
         with self._lock:
+            self._check_open()
             self.conn.execute(
                 """\
         DELETE
@@ -127,6 +138,7 @@ INSERT OR REPLACE INTO cachepot
     def delete_expired(self) -> int:
         """Delete all expired rows and return the number of deleted rows."""
         with self._lock:
+            self._check_open()
             cur = self.conn.execute(
                 """\
         DELETE

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -67,7 +67,7 @@ def test_sqlite_close_closes_connection() -> None:
         cachestore.save(b"1", b"2", expire_seconds=1)
         cachestore.close()
 
-        with pytest.raises(sqlite3.ProgrammingError):
+        with pytest.raises(RuntimeError, match="already closed"):
             cachestore.load(b"1")
 
 
@@ -77,8 +77,26 @@ def test_sqlite_context_manager_closes_connection() -> None:
             cachestore.save(b"1", b"2", expire_seconds=1)
             assert cachestore.load(b"1") == b"2"
 
-        with pytest.raises(sqlite3.ProgrammingError):
+        with pytest.raises(RuntimeError, match="already closed"):
             cachestore.load(b"1")
+
+
+def test_use_after_close_raises_runtime_error() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name)
+        cachestore.save(b"k", b"v", expire_seconds=60)
+        cachestore.close()
+
+        with pytest.raises(RuntimeError, match="already closed"):
+            cachestore.save(b"k2", b"v2", expire_seconds=60)
+        with pytest.raises(RuntimeError, match="already closed"):
+            cachestore.load(b"k")
+        with pytest.raises(RuntimeError, match="already closed"):
+            cachestore.exists(b"k")
+        with pytest.raises(RuntimeError, match="already closed"):
+            cachestore.delete(b"k")
+        with pytest.raises(RuntimeError, match="already closed"):
+            cachestore.delete_expired()
 
 
 def test_expire() -> None:


### PR DESCRIPTION
## Summary

`SQLiteCacheBackend.close()` closed the underlying SQLite connection but did
not record that the object had been closed. Any subsequent call to `save`,
`load`, `exists`, `delete`, or `delete_expired` would raise
`sqlite3.ProgrammingError: Cannot operate on a closed database.`  — an
internal SQLite detail that leaks through the public API abstraction.

## Changes

- `cachepot/backend/sqlite.py`: added `_closed: bool` field (initialised to
  `False`); `close()` now sets `_closed = True` inside the lock before closing
  the connection; a new `_check_open()` helper raises `RuntimeError("SQLiteCacheBackend is already closed")`
  when called after `close()`. Every public method calls `_check_open()`
  inside its `_lock` block.
- `tests/backend/test_sqlite.py`: updated `test_sqlite_close_closes_connection`
  and `test_sqlite_context_manager_closes_connection` to expect `RuntimeError`
  instead of `sqlite3.ProgrammingError`; added
  `test_use_after_close_raises_runtime_error` which exercises all five methods
  after `close()`.

## Verification

All 57 tests pass (`uv run poe test`). Lint and type-check clean (`uv run poe
check`). Collateral check: no violations.
