### PR TITLE
fix: source redis dev-dep from the optional-dep extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "ruff",
     "setuptools-scm",
     "mypy",
-    "redis>=8,<9",
+    "cachepot[redis]",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

`pyproject.toml` declared `redis>=8,<9` in two places:
- `[project.optional-dependencies].redis` — consumed by `pip install cachepot[redis]`
- `[dependency-groups].dev` — consumed by `uv sync` in the dev environment

When an automated updater (Renovate, Dependabot) bumps only one entry, the
CI redis version and the published package requirement silently diverge.

## Change

Replace `"redis>=8,<9"` in `[dependency-groups].dev` with `"cachepot[redis]"`.
uv resolves this as the local project with its `redis` extra, installing
whatever version `[project.optional-dependencies].redis` requires. The
constraint is now defined once; any future Renovate bump touches a single line.

## Verification

`uv sync` succeeds; `import redis` shows version 8.0.0 (within `>=8,<9`).
All 56 tests pass. Lint and type-check clean.
