### PR TITLE
docs: use top-level imports as canonical path in README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ $ pip install cachepot
 ## Usage
 
 ```python
->>> from cachepot.store import CacheStore
->>> from cachepot.backend.filesystem import FileSystemCacheBackend
->>> from cachepot.serializer.pickle import PickleSerializer
+>>> from cachepot import CacheStore, FileSystemCacheBackend, PickleSerializer
 >>> store = CacheStore(
 ...     namespace='testing',
 ...     key_serializer=PickleSerializer(),

--- a/cachepot/__init__.py
+++ b/cachepot/__init__.py
@@ -11,8 +11,10 @@ from .backend.sqlite import SQLiteCacheBackend
 from .serializer.json import JSONSerializer
 from .serializer.pickle import PickleSerializer
 from .serializer.str import StringSerializer
+from .store import CacheStore
 
 __all__ = [
+    "CacheStore",
     "FileSystemCacheBackend",
     "JSONSerializer",
     "PickleSerializer",

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,10 +10,13 @@ from unittest.mock import MagicMock
 import pytest
 from typing_extensions import assert_type
 
-from cachepot.backend.filesystem import FileSystemCacheBackend
-from cachepot.serializer.pickle import PickleSerializer
-from cachepot.serializer.str import StringSerializer
-from cachepot.store import CacheProxyProtocol, CacheStore
+from cachepot import (
+    CacheStore,
+    FileSystemCacheBackend,
+    PickleSerializer,
+    StringSerializer,
+)
+from cachepot.store import CacheProxyProtocol
 
 if TYPE_CHECKING:
     typed_proxy = cast(CacheProxyProtocol[str, int], None)


### PR DESCRIPTION
## Summary

`cachepot/__init__.py` re-exports `FileSystemCacheBackend`, `SQLiteCacheBackend`,
`JSONSerializer`, `PickleSerializer`, and `StringSerializer` at the top level,
but the README and tests continued to use the older deep-import paths, leaving
users uncertain which path is recommended.

This PR resolves the ambiguity by:

- Adding `CacheStore` to the top-level package exports, completing the public API
- Updating the README usage example to `from cachepot import CacheStore, FileSystemCacheBackend, PickleSerializer`
- Updating `tests/test_store.py` to import from `cachepot` directly

The deep-import paths (`from cachepot.backend.filesystem import ...`) remain
valid and are still used in the backend-specific test files.  Only the
user-facing integration tests and documentation now use the canonical top-level path.

## Changes

- `cachepot/__init__.py`: add `CacheStore` to `__all__` and top-level imports
- `README.md`: update Usage example to top-level import pattern
- `tests/test_store.py`: update imports to use `from cachepot import ...`

## Test plan

- [ ] `uv run poe check` passes (ruff + mypy)
- [ ] `uv run poe test` passes (all 56 tests green)