### PR TITLE
fix: handle zero expire_seconds in Redis backend

### DIFF
--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -22,7 +22,13 @@ class RedisCacheBackend(CacheBackendProtocol):
         # ``SET key value EX seconds`` is a single Redis command, so the
         # value and its TTL land together. The previous pipeline form
         # could leave the key without a TTL if EXPIRE failed after SET.
-        self.redis.set(key, value, ex=to_timedelta(expire_seconds))
+        td = to_timedelta(expire_seconds)
+        if td.total_seconds() == 0:
+            # Redis rejects EX=0. A zero-second TTL means the entry expires
+            # immediately; skip the write so load() returns None, matching
+            # FileSystem and SQLite backend behaviour.
+            return
+        self.redis.set(key, value, ex=td)
 
     def load(self, key: bytes) -> bytes | None:
         return cast(bytes, self.redis.get(key))

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -1,5 +1,6 @@
 import time
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import redis
 
@@ -78,3 +79,21 @@ def test_save_accepts_timedelta_expire_seconds() -> None:
         assert cachestore.load(b"td-key") == b"v"
     finally:
         cachestore.delete(b"td-key")
+
+
+def test_save_zero_expire_skips_write() -> None:
+    """expire_seconds=0 must not raise a ResponseError.
+
+    Redis rejects EX=0 at the server level.  The backend handles this by
+    skipping the write entirely — the result is the same as an immediately
+    expired entry: load() returns None, matching FileSystem and SQLite
+    backend behaviour.
+    """
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+    cachestore = RedisCacheBackend(mock_redis)
+
+    cachestore.save(b"key", b"value", expire_seconds=0)
+
+    mock_redis.set.assert_not_called()
+    assert cachestore.load(b"key") is None


### PR DESCRIPTION
## Summary

Calling `save(key, value, expire_seconds=0)` on `RedisCacheBackend` raised
a `ResponseError` because Redis rejects `EX 0` as an invalid expiry.
`FileSystemCacheBackend` and `SQLiteCacheBackend` both treated zero TTL as
an immediately-expired entry without raising, so the Redis backend's
behaviour was inconsistent.

This PR fixes the Redis backend to match the other backends:

- If `expire_seconds=0`, skip the `SET` command entirely.
- `load()` will return `None` (same as an immediately-expired entry on
  FileSystem and SQLite), so the caller observes a cache miss — no
  exception.

## Changes

- `cachepot/backend/redis.py`: early-return in `save()` when the
  computed timedelta is zero, avoiding the invalid `EX 0` command.
- `tests/backend/test_redis.py`: new unit test (`test_save_zero_expire_skips_write`)
  using a `MagicMock` Redis client — does not require a live Redis server.

## Test plan

- [ ] `uv run poe check` (ruff + mypy) passes
- [ ] `uv run pytest tests/backend/test_redis.py::test_save_zero_expire_skips_write` passes
- [ ] Full test matrix via CI (Redis tests require `docker-compose.test.yml`)