### PR TITLE
fix: treat filesystem expire_at boundary as expired to match SQLite backend

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -93,7 +93,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
 
     def __is_expired(self, path: pathlib.Path) -> bool:
         ts = self.__read_expire_timestamp(path)
-        return ts is not None and ts < time.time()
+        return ts is not None and ts <= time.time()
 
     def exists(self, key: bytes) -> bool:
         path = self.__get_real_path(key)

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -353,17 +353,16 @@ def test_expiry_boundary_is_treated_as_expired(
     This matches the SQLite backend which uses ``expire_at > ?`` (strict
     greater-than), meaning the entry is not returned when now == expire_at.
     """
-    now = _FrozenDatetime(2026, 5, 25, 10, 30, 15, 0)
+    now = 1748169015.0
     expire_seconds = 60.0
-    _FrozenDatetime.frozen_now = now
-    monkeypatch.setattr(filesystem_backend, "datetime", _FrozenDatetime)
+    monkeypatch.setattr(filesystem_backend.time, "time", lambda: now)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_dir = pathlib.Path(tmpdir)
         cachestore = FileSystemCacheBackend(cache_dir)
         key = b"boundary"
         cachestore.save(key, b"value", expire_seconds=expire_seconds)
-        expected_expire_at = now.timestamp() + expire_seconds
+        expected_expire_at = now + expire_seconds
 
         monkeypatch.setattr(
             filesystem_backend.time,

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -343,3 +343,33 @@ def test_exists_does_not_delete_expired_entry() -> None:
 
         assert not cachestore.exists(key)
         assert realpath.exists(), "exists() must not delete the file"
+
+
+def test_expiry_boundary_is_treated_as_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At exactly expire_at, the entry must be treated as expired.
+
+    This matches the SQLite backend which uses ``expire_at > ?`` (strict
+    greater-than), meaning the entry is not returned when now == expire_at.
+    """
+    now = _FrozenDatetime(2026, 5, 25, 10, 30, 15, 0)
+    expire_seconds = 60.0
+    _FrozenDatetime.frozen_now = now
+    monkeypatch.setattr(filesystem_backend, "datetime", _FrozenDatetime)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"boundary"
+        cachestore.save(key, b"value", expire_seconds=expire_seconds)
+        expected_expire_at = now.timestamp() + expire_seconds
+
+        monkeypatch.setattr(
+            filesystem_backend.time,
+            "time",
+            lambda: expected_expire_at,
+        )
+
+        assert cachestore.load(key) is None
+        assert cachestore.exists(key) is False


### PR DESCRIPTION
## Summary

`FileSystemCacheBackend.__is_expired` used strict less-than (`<`) to test
whether the stored expiry timestamp had passed, meaning that at exactly
`t == expire_at` the entry was still treated as **valid**:

```python
return self.__read_expire_timestamp(path) < time.time()
```

`SQLiteCacheBackend` used strict greater-than (`>`) on the load/exists
queries, meaning that at `t == expire_at` the entry was **not returned**
(expired):

```sql
AND expire_at > ?
```

The two backends disagreed at the exact boundary instant. While the
probability of hitting the exact nanosecond in production is negligible,
the inconsistency causes unit tests that freeze time at `expire_at` to
produce different results depending on which backend is under test.

## Changes

- `cachepot/backend/filesystem.py`: change `<` to `<=` in
  `__is_expired`, so that at `t == expire_at` the filesystem backend
  treats the entry as expired, consistent with the SQLite backend.

- `tests/backend/test_filesystem.py`: add
  `test_expiry_boundary_is_treated_as_expired` to assert that
  `load()` returns `None` and `exists()` returns `False` when
  the frozen clock equals `expire_at` exactly.

## Verification

- 50 non-Redis tests pass (`uv run pytest tests/ --ignore=tests/backend/test_redis.py`).
- `ruff check` and `mypy` report no issues (`uv run poe check`).