### PR TITLE
fix: remove redundant UNIQUE index on (key, expire_at) in SQLite backend

### DIFF
--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -33,14 +33,7 @@ CREATE TABLE IF NOT EXISTS cachepot
            , expire_at timestamp
            )""",
     )
-    conn.execute(
-        """\
-CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot
-                 ON cachepot
-                  ( key
-                  , expire_at
-                  )""",
-    )
+    conn.execute("DROP INDEX IF EXISTS idx_cachepot")
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     if version != _SCHEMA_VERSION:
         _migrate(conn, version)


### PR DESCRIPTION
## Summary

The `CREATE UNIQUE INDEX IF NOT EXISTS idx_cachepot ON cachepot (key, expire_at)` in `_init_schema()` adds no constraint beyond what `PRIMARY KEY` on `key` already guarantees.

Since `key` is `PRIMARY KEY` (and therefore unique), no two rows can share the same `key`. The composite `(key, expire_at)` tuple is automatically unique — the index was a dead index that could mislead future maintainers into believing a multi-row-per-key invariant was intentional.

## Changes

- Remove `CREATE UNIQUE INDEX` from `_init_schema()`
- Add `DROP INDEX IF EXISTS idx_cachepot` so existing databases drop the index on next startup

## Verification

- All SQLite backend tests pass (Redis tests skipped; no Redis in CI for this change)
- `ruff check` passes with no new findings
