### PR TITLE
fix: compute expire_at inside lock in FileSystemCacheBackend.save()

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -38,10 +38,9 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         *,
         expire_seconds: Expiry,
     ) -> None:
-        expire_at = datetime.now() + to_timedelta(expire_seconds)
-        expire_timestamp = expire_at.timestamp()
-
         with self.__lock:
+            expire_at = datetime.now() + to_timedelta(expire_seconds)
+            expire_timestamp = expire_at.timestamp()
             realpath = self.__get_real_path(key)
             realpath.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary

`FileSystemCacheBackend.save()` computed `expire_at = datetime.now() + to_timedelta(expire_seconds)` before acquiring `self.__lock`. Any time spent waiting for the lock was deducted from the effective TTL. Under I/O contention or `os.fsync` stalls, the gap could be measurable.

The SQLite backend had an identical issue, fixed in commit dc2318b (`audit-sqlite-expire-at-prelock-001`). This PR applies the same one-line fix to the filesystem backend.

## Change

Move `expire_at` and `expire_timestamp` computation inside `with self.__lock:` so the TTL clock starts at lock acquisition, matching the contract that "TTL seconds after write completes."

## Verification

- All filesystem backend tests pass
- `ruff check` passes with no new findings
