### PR TITLE
ci: run Python checks in parallel

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -48,20 +48,21 @@ jobs:
           uv python pin ${{ matrix.python }}
           uv sync
 
-      - name: Lint
-        run: uv run poe check
+      - parallel:
+          - name: Lint
+            run: uv run poe check
 
-      - name: Check Python version
-        run: |
-          actual_version=$(uv run python --version)
-          expected_version="Python ${{ matrix.python }}"
-          if [[ "$actual_version" != *"$expected_version"* ]]; then
-            echo "Expected $expected_version, but got $actual_version"
-            exit 1
-          fi
+          - name: Check Python version
+            run: |
+              actual_version=$(uv run python --version)
+              expected_version="Python ${{ matrix.python }}"
+              if [[ "$actual_version" != *"$expected_version"* ]]; then
+                echo "Expected $expected_version, but got $actual_version"
+                exit 1
+              fi
 
-      - name: Test
-        run: uv run poe test
+          - name: Test
+            run: uv run poe test
   
       - name: Coverage
         run: uv run poe coverage-xml


### PR DESCRIPTION
## Summary

- Run independent Python validation steps in `.github/workflows/python-test.yml` with GitHub Actions step-level `parallel` execution.
- Keep coverage generation or reporting sequential after the test step completes.

## Validation

- Parsed `.github/workflows/python-test.yml` as YAML.
- Local pre-commit check passed.
- Local `uv run poe test` requires Redis on localhost and failed without that service; this workflow defines a Redis service for CI.

## Notes

- Local `actionlint 1.7.12` does not recognize the new `parallel` step syntax yet.
