### PR TITLE
fix: FileSystemCacheBackend silently collapses corrupted expiry headers

### DIFF
--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -2,6 +2,7 @@ import contextlib
 import hashlib
 import os
 import pathlib
+import re
 import struct
 import tempfile
 import threading
@@ -16,6 +17,11 @@ PathLike = pathlib.Path | str
 
 _EXPIRY_HEADER_FORMAT = ">d"
 _EXPIRY_HEADER_SIZE = struct.calcsize(_EXPIRY_HEADER_FORMAT)
+_CACHE_ENTRY_NAME_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CorruptExpiryHeaderError(ValueError):
+    """Raised when a cache entry has an unreadable expiry header."""
 
 
 class FileSystemCacheBackend(CacheBackendProtocol):
@@ -80,26 +86,35 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         return None
 
     def __is_loadable(self, path: pathlib.Path) -> bool:
-        ts = self.__read_expire_timestamp(path)
-        return ts is not None and not self.__delete_if_expired(path)
+        self.__read_expire_timestamp(path)
+        return not self.__delete_if_expired(path)
 
     def __can_load(self, path: pathlib.Path) -> bool:
         return path.is_file() and self.__is_loadable(path)
 
-    def __read_expire_timestamp(self, path: pathlib.Path) -> float | None:
-        with contextlib.suppress(OSError, struct.error), path.open("rb") as f:
+    def __read_expire_timestamp(self, path: pathlib.Path) -> float:
+        with path.open("rb") as f:
             raw = f.read(_EXPIRY_HEADER_SIZE)
-            return struct.unpack(_EXPIRY_HEADER_FORMAT, raw)[0]
-        return None
+        if len(raw) < _EXPIRY_HEADER_SIZE:
+            raise CorruptExpiryHeaderError(
+                f"cache entry {path.name} has a truncated expiry header",
+            )
+        return struct.unpack(_EXPIRY_HEADER_FORMAT, raw)[0]
 
     def __is_expired(self, path: pathlib.Path) -> bool:
         ts = self.__read_expire_timestamp(path)
-        return ts is not None and ts <= time.time()
+        return ts <= time.time()
+
+    def __is_cache_entry_path(self, path: pathlib.Path) -> bool:
+        return _CACHE_ENTRY_NAME_RE.fullmatch(path.name) is not None
 
     def exists(self, key: bytes) -> bool:
         path = self.__get_real_path(key)
         with self.__lock:
-            return path.is_file() and not self.__is_expired(path)
+            try:
+                return path.is_file() and not self.__is_expired(path)
+            except FileNotFoundError:
+                return False
 
     def delete(self, key: bytes) -> None:
         with self.__lock, contextlib.suppress(FileNotFoundError):
@@ -110,7 +125,8 @@ class FileSystemCacheBackend(CacheBackendProtocol):
             return sum(
                 1
                 for path in self.path.iterdir()
-                if self.__delete_file_if_expired(path)
+                if self.__is_cache_entry_path(path)
+                and self.__delete_file_if_expired(path)
             )
         return 0
 

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -324,9 +324,26 @@ def test_delete_expired_skips_file_with_truncated_header() -> None:
         assert short_file.exists()
 
 
-def test_load_returns_none_for_truncated_header_file() -> None:
-    """load() must return None for a file at the key-derived path whose header
-    is too short to unpack (e.g. a partially written file)."""
+def test_delete_expired_raises_for_truncated_cache_entry_header() -> None:
+    """A truncated cache entry header should be surfaced as corruption."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"collision-key"
+        key_path = _cache_entry_path(cache_dir, key)
+        key_path.write_bytes(b"\x00\x01")
+
+        with pytest.raises(
+            filesystem_backend.CorruptExpiryHeaderError,
+            match="truncated expiry header",
+        ):
+            cachestore.delete_expired()
+
+        assert key_path.exists()
+
+
+def test_load_raises_for_truncated_header_file() -> None:
+    """load() must surface a corrupted cache entry header as an error."""
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_dir = pathlib.Path(tmpdir)
         cachestore = FileSystemCacheBackend(cache_dir)
@@ -334,7 +351,29 @@ def test_load_returns_none_for_truncated_header_file() -> None:
         key_path = _cache_entry_path(cache_dir, key)
         key_path.write_bytes(b"\x00\x01")  # shorter than the 8-byte header
 
-        assert cachestore.load(key) is None
+        with pytest.raises(
+            filesystem_backend.CorruptExpiryHeaderError,
+            match="truncated expiry header",
+        ):
+            cachestore.load(key)
+        assert key_path.exists()
+
+
+def test_exists_raises_for_truncated_header_file() -> None:
+    """exists() must also surface a corrupted cache entry header."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir)
+        key = b"collision-key"
+        key_path = _cache_entry_path(cache_dir, key)
+        key_path.write_bytes(b"\x00\x01")
+
+        with pytest.raises(
+            filesystem_backend.CorruptExpiryHeaderError,
+            match="truncated expiry header",
+        ):
+            cachestore.exists(key)
+
         assert key_path.exists()
 
 


### PR DESCRIPTION
## Finding

`FileSystemCacheBackend` does not surface corrupted expiry headers as exceptions; it collapses them to `float("-inf")` and treats the entry as expired, so the read failure proceeds to the deletion path with its cause invisible.

## Why

`__read_expire_timestamp()` swallows `OSError` / `struct.error` and returns `float("-inf")`, which `__is_expired()` always judges as expired, so file corruption or partial-write failures never reach the caller. On the error path, silent deletion wins over an observable exception.

## Impact

With corrupted cache files, mixed legacy formats, or partially written files, users receive no exception pointing at the cause — only what looks like a cache miss or a deletion. Diagnosing data corruption becomes difficult and problems hide silently.
