### PR TITLE
Removed the package-root re-export of `PickleSerializer`, kept the expl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ $ pip install cachepot
 ## Usage
 
 ```python
->>> from cachepot import CacheStore, FileSystemCacheBackend, PickleSerializer
+>>> from cachepot import CacheStore, FileSystemCacheBackend
+>>> from cachepot.serializer.pickle import PickleSerializer
 >>> store = CacheStore(
 ...     namespace='testing',
 ...     key_serializer=PickleSerializer(),
@@ -39,9 +40,11 @@ observe that count.  Redis handles TTL expiry server-side, so its backend
 returns `None` when the deleted-entry count is unknown.
 
 > **Security note**: `PickleSerializer` uses Python's `pickle` module, which can
-> execute arbitrary code during deserialization. Only use it when the cache
-> backend storage is fully under your control and trusted. For untrusted
-> environments, prefer `JsonSerializer` or `MsgpackSerializer` instead.
+> execute arbitrary code during deserialization. The serializer is intentionally
+> not exported from `cachepot`'s top-level namespace. Import it explicitly from
+> `cachepot.serializer.pickle` only when the cache backend storage is fully
+> under your control and trusted. For untrusted environments, prefer
+> `JsonSerializer` or `MsgpackSerializer` instead.
 
 ### Proxy method
 

--- a/cachepot/__init__.py
+++ b/cachepot/__init__.py
@@ -10,7 +10,6 @@ from ._warnings import CachepotWarning
 from .backend.filesystem import FileSystemCacheBackend
 from .backend.sqlite import SQLiteCacheBackend
 from .serializer.json import JSONSerializer
-from .serializer.pickle import PickleSerializer
 from .serializer.str import StringSerializer
 from .store import CacheStore
 
@@ -19,7 +18,6 @@ __all__ = [
     "CachepotWarning",
     "FileSystemCacheBackend",
     "JSONSerializer",
-    "PickleSerializer",
     "SQLiteCacheBackend",
     "StringSerializer",
     "__version__",

--- a/cachepot/serializer/pickle.py
+++ b/cachepot/serializer/pickle.py
@@ -1,9 +1,11 @@
 import io
 import pickle
 import sys
+import warnings
 from itertools import islice
 from typing import Any
 
+from cachepot._warnings import CachepotWarning
 from cachepot.serializer import SerializerProtocol
 
 PICKLE_PROTOCOL = 4
@@ -99,6 +101,14 @@ class PickleSerializer(SerializerProtocol[Any]):
         :class:`cachepot.serializer.msgpack.MsgpackSerializer` for
         untrusted environments.
     """
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "PickleSerializer can execute arbitrary code during "
+            "deserialization. Use it only with trusted cache data.",
+            CachepotWarning,
+            stacklevel=2,
+        )
 
     def serialize(self, data: Any) -> bytes:
         return _pickle_dumps(data)

--- a/tests/serializer/test_pickle.py
+++ b/tests/serializer/test_pickle.py
@@ -4,6 +4,9 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
+import pytest
+
+from cachepot._warnings import CachepotWarning
 from cachepot.serializer.pickle import PICKLE_PROTOCOL, PickleSerializer
 
 
@@ -12,8 +15,13 @@ class A:
     x: int
 
 
+def _new_pickle_serializer() -> PickleSerializer:
+    with pytest.warns(CachepotWarning):
+        return PickleSerializer()
+
+
 def test_pickle_serializer() -> None:
-    serializer = PickleSerializer()
+    serializer = _new_pickle_serializer()
 
     patterns = [
         1,
@@ -31,7 +39,7 @@ def test_pickle_serializer() -> None:
 
 
 def test_pickle_serializer_uses_stable_protocol() -> None:
-    serializer = PickleSerializer()
+    serializer = _new_pickle_serializer()
 
     assert serializer.serialize("key") == pickle.dumps(
         "key",
@@ -44,13 +52,13 @@ def test_pickle_serializer_stabilizes_hash_randomized_sets() -> None:
     second = _serialize_frozenset_with_hash_seed("2")
 
     assert first == second
-    assert PickleSerializer().deserialize(first) == frozenset(
+    assert _new_pickle_serializer().deserialize(first) == frozenset(
         {"alpha", "bravo", "charlie"},
     )
 
 
 def test_pickle_serializer_stabilizes_dict_insertion_order() -> None:
-    serializer = PickleSerializer()
+    serializer = _new_pickle_serializer()
     d1 = {"a": 1, "b": 2}
     d2 = {"b": 2, "a": 1}
     assert d1 == d2

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,9 +15,10 @@ import cachepot
 from cachepot import (
     CacheStore,
     FileSystemCacheBackend,
-    PickleSerializer,
     StringSerializer,
 )
+from cachepot._warnings import CachepotWarning
+from cachepot.serializer.pickle import PickleSerializer
 from cachepot.store import CacheProxyProtocol
 
 if TYPE_CHECKING:
@@ -30,12 +31,17 @@ if TYPE_CHECKING:
     assert_type(typed_store.delete_expired(), int | None)
 
 
+def _new_pickle_serializer() -> PickleSerializer:
+    with pytest.warns(CachepotWarning):
+        return PickleSerializer()
+
+
 def test_basis() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         cachestore = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=1,
         )
@@ -60,7 +66,7 @@ def test_has_distinguishes_miss_from_stored_none() -> None:
         store: CacheStore[str, None] = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -77,7 +83,7 @@ def test_delete_expired() -> None:
         store = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=1,
         )
@@ -99,7 +105,7 @@ def test_delete_expired_propagates_unknown_count() -> None:
     store: CacheStore[str, int] = CacheStore(
         namespace="testing",
         key_serializer=StringSerializer(),
-        value_serializer=PickleSerializer(),
+        value_serializer=_new_pickle_serializer(),
         backend=backend,
         default_expire_seconds=60,
     )
@@ -115,7 +121,7 @@ def test_proxy_caches_none_return_value() -> None:
         cachestore = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -139,7 +145,7 @@ def test_proxy_expire_none_uses_store_default() -> None:
     store: CacheStore[str, int] = CacheStore(
         namespace="testing",
         key_serializer=StringSerializer(),
-        value_serializer=PickleSerializer(),
+        value_serializer=_new_pickle_serializer(),
         backend=backend,
         default_expire_seconds=60,
     )
@@ -182,7 +188,7 @@ def test_proxy_no_double_execution_under_concurrency() -> None:
         store = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -201,7 +207,7 @@ def test_proxy_misses_for_different_keys_run_concurrently() -> None:
         store: CacheStore[str, int] = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -220,12 +226,17 @@ def test_proxy_misses_for_different_keys_run_concurrently() -> None:
             assert second.result(timeout=1) == 2
 
 
+def test_pickle_serializer_is_not_top_level_export() -> None:
+    assert "PickleSerializer" not in cachepot.__all__
+    assert not hasattr(cachepot, "PickleSerializer")
+
+
 def test_proxy_miss_does_not_block_other_key_get() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         store: CacheStore[str, int] = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -264,7 +275,7 @@ def test_proxy_nested_same_store_does_not_deadlock() -> None:
         store = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -283,14 +294,14 @@ def test_namespace_key_no_collision() -> None:
         store_a = CacheStore(
             namespace="a",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
         store_ab = CacheStore(
             namespace="a:b",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -305,7 +316,7 @@ def test_proxy_requires_cache_key_at_runtime() -> None:
         cachestore = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -328,7 +339,7 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
     store: CacheStore[str, int] = CacheStore(
         namespace="testing",
         key_serializer=StringSerializer(),
-        value_serializer=PickleSerializer(),
+        value_serializer=_new_pickle_serializer(),
         backend=backend,
         default_expire_seconds=60,
     )
@@ -364,7 +375,7 @@ def _make_store(tmpdir: str) -> CacheStore[str, str]:
     return CacheStore(
         namespace="testing",
         key_serializer=StringSerializer(),
-        value_serializer=PickleSerializer(),
+        value_serializer=_new_pickle_serializer(),
         backend=FileSystemCacheBackend(tmpdir),
         default_expire_seconds=60,
     )
@@ -408,7 +419,7 @@ def test_direct_put_get_is_thread_safe() -> None:
         store: CacheStore[str, int] = CacheStore(
             namespace="testing",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )
@@ -430,7 +441,7 @@ def test_cachestore_context_manager_calls_backend_close() -> None:
     store: CacheStore[str, int] = CacheStore(
         namespace="testing",
         key_serializer=StringSerializer(),
-        value_serializer=PickleSerializer(),
+        value_serializer=_new_pickle_serializer(),
         backend=backend,
         default_expire_seconds=60,
     )
@@ -453,7 +464,7 @@ def test_get_raises_with_key_context_on_deserialize_failure() -> None:
         store = CacheStore(
             namespace="my-ns",
             key_serializer=StringSerializer(),
-            value_serializer=PickleSerializer(),
+            value_serializer=_new_pickle_serializer(),
             backend=FileSystemCacheBackend(tmpdir),
             default_expire_seconds=60,
         )


### PR DESCRIPTION
## Summary

Removed the package-root re-export of `PickleSerializer`, kept the explicit
`cachepot.serializer.pickle` import path, and added a `CachepotWarning` on
instantiation to make the unsafe serializer harder to miss.
