### PR TITLE
Surface cache write degradation through logs and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ In short, this works as proxy. This helps to make codes straight forward.
 The proxied function requires the keyword-only argument `cache_key` and
 can also accept `expire_seconds`.
 
+When a proxied cache write fails, `cachepot` keeps returning the computed
+result, emits a `CachepotWarning`, logs the failure on the `cachepot.store`
+logger, and increments `store.cache_write_failures`. This lets applications
+forward failures to their existing logging or metrics pipeline without giving
+up graceful degradation.
+
 ## Core idea
 
 Serializers convert python objects into bytes.

--- a/cachepot/store/__init__.py
+++ b/cachepot/store/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import threading
 import warnings
 import weakref
@@ -14,6 +15,8 @@ from cachepot.serializer import SerializerProtocol
 T = TypeVar("T", contravariant=True)
 S = TypeVar("S")
 S_co = TypeVar("S_co", covariant=True)
+
+logger = logging.getLogger(__name__)
 
 
 class CacheProxyProtocol(Protocol[T, S_co]):
@@ -81,6 +84,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
     value_serializer: SerializerProtocol[S]
     backend: CacheBackendProtocol
     default_expire_seconds: Expiry
+    cache_write_failures: int
 
     def __init__(
         self,
@@ -95,6 +99,7 @@ class CacheStore(CacheStoreProtocol[T, S]):
         self.value_serializer = value_serializer
         self.backend = backend
         self.default_expire_seconds = default_expire_seconds
+        self.cache_write_failures = 0
         self._lock = threading.RLock()
         self._key_locks: weakref.WeakValueDictionary[bytes, Any] = (
             weakref.WeakValueDictionary()
@@ -213,10 +218,14 @@ class CacheStore(CacheStoreProtocol[T, S]):
         **Cache write failures are demoted to warnings.**  When the proxy
         stores a computed result and the backend raises any exception,
         the exception is caught and emitted via :func:`warnings.warn` instead
-        of propagating to the caller.  The original function's return value
-        is still returned normally.  This is intentional graceful degradation:
-        the proxy remains functional even when the backend is unavailable,
-        at the cost of recomputing the result on every call.
+        of propagating to the caller.  The failure is also logged with the
+        ``cachepot.store`` logger and increments the store's
+        ``cache_write_failures`` counter so applications can monitor
+        degradation without relying on the process-global warnings filter.
+        The original function's return value is still returned normally.  This
+        is intentional graceful degradation: the proxy remains functional even
+        when the backend is unavailable, at the cost of recomputing the result
+        on every call.
 
         This differs from calling :meth:`put` directly, where backend
         exceptions propagate unchanged to the caller.  If your application
@@ -275,6 +284,14 @@ class CacheStore(CacheStoreProtocol[T, S]):
         try:
             self.put(cache_key, result, expire_seconds=expire_seconds)
         except Exception as exc:
+            with self._lock:
+                self.cache_write_failures += 1
+            logger.warning(
+                "Cache write failed: namespace=%r, key=%r",
+                self.namespace,
+                cache_key,
+                exc_info=exc,
+            )
             warnings.warn(
                 f"Cache write failed: "
                 f"namespace={self.namespace!r}, "

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import functools
+import logging
 import tempfile
 import threading
 import time
@@ -358,6 +359,7 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
 
     assert result == 99
     assert call_count == 1
+    assert store.cache_write_failures == 1
     cache_write_warnings = [
         warning
         for warning in caught
@@ -369,6 +371,30 @@ def test_proxy_returns_result_when_backend_write_fails() -> None:
         cache_write_warnings[0].category,
         cachepot.CachepotWarning,
     )
+
+
+def test_proxy_logs_write_failures(caplog: pytest.LogCaptureFixture) -> None:
+    backend = MagicMock()
+    backend.load.return_value = None
+    backend.save.side_effect = OSError("No space left on device")
+
+    store: CacheStore[str, int] = CacheStore(
+        namespace="testing",
+        key_serializer=StringSerializer(),
+        value_serializer=_new_pickle_serializer(),
+        backend=backend,
+        default_expire_seconds=60,
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="cachepot.store"),
+        pytest.warns(CachepotWarning, match="Cache write failed"),
+    ):
+        store.proxy(lambda: 99)(cache_key="k")
+
+    assert store.cache_write_failures == 1
+    assert "Cache write failed" in caplog.text
+    assert "namespace='testing'" in caplog.text
 
 
 def _make_store(tmpdir: str) -> CacheStore[str, str]:


### PR DESCRIPTION
## Summary
- log proxy cache write failures through the `cachepot.store` logger while preserving graceful degradation
- expose a per-store `cache_write_failures` counter so applications can detect repeated backend save failures
- document and test the new observability path alongside the existing `CachepotWarning`

## Why
Proxy writes intentionally fall back to warnings so callers still receive computed results when the backend is unavailable. In long-running services, warnings alone are easy to miss, which makes cache degradation harder to diagnose.

## Verification
- `uv run poe check`
- `uv run pytest tests/test_store.py`
