### PR TITLE
Clean expired SQLite rows during later writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ pip install cachepot
 `delete_expired()` returns the number of entries removed when the backend can
 observe that count.  Redis handles TTL expiry server-side, so its backend
 returns `None` when the deleted-entry count is unknown.
+SQLite also opportunistically removes expired rows during later writes, while
+`delete_expired()` remains available when you want to force a cleanup cycle.
 
 > **Security note**: `PickleSerializer` uses Python's `pickle` module, which can
 > execute arbitrary code during deserialization. The serializer is intentionally

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -10,16 +10,30 @@ from cachepot.expire import Expiry, to_timedelta
 
 ConnectionLike = str | pathlib.Path | sqlite3.Connection
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
+_AUTOMATIC_EXPIRED_CLEANUP_INTERVAL = to_timedelta(60)
 
 
-def _migrate(conn: sqlite3.Connection, from_version: int) -> None:
+def _migrate_to_v2(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cachepot_expire_at "
+        "ON cachepot(expire_at)",
+    )
+
+
+def _raise_for_future_schema(from_version: int) -> None:
     if from_version > _SCHEMA_VERSION:
         raise RuntimeError(
             f"cachepot database schema version {from_version} is newer than "
             f"the current library version ({_SCHEMA_VERSION}). "
             "Upgrade cachepot to open this database.",
         )
+
+
+def _migrate(conn: sqlite3.Connection, from_version: int) -> None:
+    _raise_for_future_schema(from_version)
+    if from_version < 2:
+        _migrate_to_v2(conn)
     conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
     conn.commit()
 
@@ -53,6 +67,7 @@ class SQLiteCacheBackend(CacheBackendProtocol):
     conn: sqlite3.Connection
     _lock: threading.Lock
     _closed: bool
+    _next_expired_cleanup_at: datetime | None
 
     def __init__(self, conn: ConnectionLike) -> None:
         if isinstance(conn, (str, pathlib.Path)):
@@ -62,6 +77,7 @@ class SQLiteCacheBackend(CacheBackendProtocol):
         self._lock = threading.Lock()
         self.conn = conn
         self._closed = False
+        self._next_expired_cleanup_at = None
 
     def close(self) -> None:
         with self._lock:
@@ -92,8 +108,10 @@ class SQLiteCacheBackend(CacheBackendProtocol):
     ) -> None:
         with self._lock:
             self._check_open()
+            current_datetime = datetime.now(timezone.utc)
+            self._maybe_delete_expired_locked(current_datetime)
             expire_at = (
-                datetime.now(timezone.utc) + to_timedelta(expire_seconds)
+                current_datetime + to_timedelta(expire_seconds)
             ).isoformat()
             self.conn.execute(
                 """\
@@ -103,6 +121,29 @@ INSERT OR REPLACE INTO cachepot
                 (key, value, expire_at),
             )
             self.conn.commit()
+
+    def _maybe_delete_expired_locked(self, current_datetime: datetime) -> None:
+        if (
+            self._next_expired_cleanup_at is not None
+            and current_datetime < self._next_expired_cleanup_at
+        ):
+            return
+        self._delete_expired_locked(current_datetime)
+        self._next_expired_cleanup_at = (
+            current_datetime + _AUTOMATIC_EXPIRED_CLEANUP_INTERVAL
+        )
+
+    def _delete_expired_locked(
+        self,
+        current_datetime: datetime,
+    ) -> sqlite3.Cursor:
+        return self.conn.execute(
+            """\
+        DELETE
+          FROM cachepot
+         WHERE expire_at <= ?""",
+            (current_datetime.isoformat(),),
+        )
 
     def load(self, key: bytes) -> bytes | None:
         with self._lock:
@@ -150,12 +191,6 @@ INSERT OR REPLACE INTO cachepot
         """Delete all expired rows and return the number of deleted rows."""
         with self._lock:
             self._check_open()
-            cur = self.conn.execute(
-                """\
-        DELETE
-          FROM cachepot
-         WHERE expire_at <= ?""",
-                (datetime.now(timezone.utc).isoformat(),),
-            )
+            cur = self._delete_expired_locked(datetime.now(timezone.utc))
             self.conn.commit()
         return cur.rowcount

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -34,18 +34,18 @@ class _AdvancingLock:
 
 
 def test_schema_version_is_set_on_new_database() -> None:
-    """A freshly initialised database must have user_version = 1."""
+    """A freshly initialised database must have user_version = 2."""
     with tempfile.NamedTemporaryFile(suffix=".db") as f:
         conn = sqlite3.connect(f.name)
         SQLiteCacheBackend(conn)
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 1
+        assert version == 2
         conn.close()
 
 
 def test_schema_version_upgrades_unversioned_database() -> None:
     """An existing database with user_version = 0 is accepted and upgraded
-    to version 1 without requiring a data migration."""
+    to version 2 without requiring a data migration."""
     with tempfile.NamedTemporaryFile(suffix=".db") as f:
         # Simulate a pre-versioning database: create the schema manually,
         # leave user_version at the SQLite default of 0.
@@ -58,14 +58,36 @@ def test_schema_version_upgrades_unversioned_database() -> None:
         conn.close()
 
         # Opening with SQLiteCacheBackend must succeed and migrate
-        # user_version to 1.
+        # user_version to 2.
         with SQLiteCacheBackend(f.name) as backend:
             backend.save(b"k", b"v", expire_seconds=60)
             assert backend.load(b"k") == b"v"
 
         conn2 = sqlite3.connect(f.name)
         version = conn2.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 1
+        assert version == 2
+        conn2.close()
+
+
+def test_schema_version_upgrades_v1_database_with_expire_index() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        conn = sqlite3.connect(f.name)
+        conn.execute(
+            "CREATE TABLE cachepot"
+            " (key BLOB PRIMARY KEY, value BLOB, expire_at timestamp)",
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+        conn.close()
+
+        SQLiteCacheBackend(f.name).close()
+
+        conn2 = sqlite3.connect(f.name)
+        version = conn2.execute("PRAGMA user_version").fetchone()[0]
+        rows = conn2.execute("PRAGMA index_list('cachepot')").fetchall()
+        index_names = {row[1] for row in rows}
+        assert version == 2
+        assert "idx_cachepot_expire_at" in index_names
         conn2.close()
 
 
@@ -180,6 +202,31 @@ def test_delete_expired() -> None:
 
         # calling again with nothing expired returns 0
         assert cachestore.delete_expired() == 0
+
+
+def test_save_automatically_cleans_expired_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start = datetime(2026, 1, 1, 0, 0, 0)
+    _CONTROLLED_CURRENT_TIME[0] = start
+
+    with tempfile.NamedTemporaryFile() as f:
+        monkeypatch.setattr(sqlite_backend, "datetime", _ControlledDateTime)
+        monkeypatch.setattr(
+            sqlite_backend,
+            "_AUTOMATIC_EXPIRED_CLEANUP_INTERVAL",
+            timedelta(seconds=0),
+        )
+        cachestore = SQLiteCacheBackend(f.name)
+        cachestore.save(b"expired", b"value", expire_seconds=1)
+
+        _CONTROLLED_CURRENT_TIME[0] = start + timedelta(seconds=2)
+        cachestore.save(b"live", b"value", expire_seconds=60)
+
+        rows = cachestore.conn.execute(
+            "SELECT key FROM cachepot ORDER BY key",
+        ).fetchall()
+        assert rows == [(b"live",)]
 
 
 def test_save_expiration_starts_after_lock_acquisition(


### PR DESCRIPTION
## Summary

- opportunistically delete expired SQLite rows during later writes
- add an `expire_at` index and schema migration so cleanup does not require a full table scan
- document that `delete_expired()` remains available for explicit maintenance runs

## Why

Expired SQLite rows were only hidden by `load()` and `exists()`, so a workload that keeps writing short-lived keys could grow the database file without bound unless callers remembered to schedule `delete_expired()` manually.

## Verification

- `uv run poe check`
- `uv run pytest tests/backend/test_sqlite.py tests/test_store.py`

## Additional notes

- `uv run poe test` still fails in this environment because the Redis backend tests require a Redis server on `localhost:6379`, which is not running here.
