### PR TITLE
fix: bound backend cache entry sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Backends save/load bytes.
 So serializers and backends are independent.
 CacheStore is the facade of them.
 
+Backends now enforce a finite per-entry size contract by default:
+`max_entry_bytes=8 * 1024 * 1024` (8 MiB). Entries larger than that are
+rejected on `save()`, and `load()` checks the backend-side size before
+materializing the payload into process memory. You can override the limit
+per backend instance when your application has a different budget.
+
 - Python3 typing supports
 - namespaces
 - Proxy method

--- a/cachepot/backend/__init__.py
+++ b/cachepot/backend/__init__.py
@@ -4,6 +4,27 @@ from typing import Protocol
 from cachepot.expire import Expiry
 
 DeletedExpiredCount = int | None
+DEFAULT_MAX_ENTRY_BYTES = 8 * 1024 * 1024
+
+
+class CacheEntryTooLargeError(ValueError):
+    """Raised when a cache entry exceeds the backend size contract."""
+
+    def __init__(
+        self,
+        *,
+        operation: str,
+        actual_bytes: int,
+        max_entry_bytes: int,
+    ) -> None:
+        self.operation = operation
+        self.actual_bytes = actual_bytes
+        self.max_entry_bytes = max_entry_bytes
+        super().__init__(
+            f"cache entry too large for {operation}: "
+            f"{actual_bytes} bytes exceeds max_entry_bytes="
+            f"{max_entry_bytes}",
+        )
 
 
 class CacheBackendProtocol(Protocol):

--- a/cachepot/backend/filesystem.py
+++ b/cachepot/backend/filesystem.py
@@ -10,7 +10,11 @@ import time
 from types import TracebackType
 from typing import BinaryIO, cast
 
-from cachepot.backend import CacheBackendProtocol
+from cachepot.backend import (
+    DEFAULT_MAX_ENTRY_BYTES,
+    CacheBackendProtocol,
+    CacheEntryTooLargeError,
+)
 from cachepot.expire import Expiry, to_timedelta
 
 PathLike = pathlib.Path | str
@@ -27,11 +31,17 @@ class CorruptExpiryHeaderError(ValueError):
 class FileSystemCacheBackend(CacheBackendProtocol):
     path: pathlib.Path
 
-    def __init__(self, path: PathLike) -> None:
+    def __init__(
+        self,
+        path: PathLike,
+        *,
+        max_entry_bytes: int = DEFAULT_MAX_ENTRY_BYTES,
+    ) -> None:
         if isinstance(path, str):
             self.path = pathlib.Path(path)
         else:
             self.path = path
+        self.max_entry_bytes = max_entry_bytes
         self.__lock = threading.RLock()
 
     def __get_real_path(self, key: bytes) -> pathlib.Path:
@@ -44,6 +54,7 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         *,
         expire_seconds: Expiry,
     ) -> None:
+        self.__ensure_entry_fits(len(value), operation="save")
         with self.__lock:
             expire_timestamp = (
                 time.time() + to_timedelta(expire_seconds).total_seconds()
@@ -80,10 +91,23 @@ class FileSystemCacheBackend(CacheBackendProtocol):
         with contextlib.suppress(FileNotFoundError):
             if not self.__can_load(path):
                 return None
+            self.__ensure_file_fits(path)
             with cast(BinaryIO, path.open("rb")) as f:
                 f.seek(_EXPIRY_HEADER_SIZE)
                 return f.read()
         return None
+
+    def __ensure_entry_fits(self, size: int, *, operation: str) -> None:
+        if size > self.max_entry_bytes:
+            raise CacheEntryTooLargeError(
+                operation=operation,
+                actual_bytes=size,
+                max_entry_bytes=self.max_entry_bytes,
+            )
+
+    def __ensure_file_fits(self, path: pathlib.Path) -> None:
+        payload_size = path.stat().st_size - _EXPIRY_HEADER_SIZE
+        self.__ensure_entry_fits(payload_size, operation="load")
 
     def __is_loadable(self, path: pathlib.Path) -> bool:
         self.__read_expire_timestamp(path)

--- a/cachepot/backend/redis.py
+++ b/cachepot/backend/redis.py
@@ -3,15 +3,26 @@ from typing import cast
 
 from redis import Redis
 
-from cachepot.backend import CacheBackendProtocol, DeletedExpiredCount
+from cachepot.backend import (
+    DEFAULT_MAX_ENTRY_BYTES,
+    CacheBackendProtocol,
+    CacheEntryTooLargeError,
+    DeletedExpiredCount,
+)
 from cachepot.expire import Expiry, to_timedelta
 
 
 class RedisCacheBackend(CacheBackendProtocol):
     redis: Redis
 
-    def __init__(self, redis_connection: Redis) -> None:
+    def __init__(
+        self,
+        redis_connection: Redis,
+        *,
+        max_entry_bytes: int = DEFAULT_MAX_ENTRY_BYTES,
+    ) -> None:
         self.redis = redis_connection
+        self.max_entry_bytes = max_entry_bytes
 
     def save(
         self,
@@ -20,6 +31,7 @@ class RedisCacheBackend(CacheBackendProtocol):
         *,
         expire_seconds: Expiry,
     ) -> None:
+        self._ensure_entry_fits(len(value), operation="save")
         # ``SET key value EX seconds`` is a single Redis command, so the
         # value and its TTL land together. The previous pipeline form
         # could leave the key without a TTL if EXPIRE failed after SET.
@@ -32,6 +44,9 @@ class RedisCacheBackend(CacheBackendProtocol):
         self.redis.set(key, value, ex=td)
 
     def load(self, key: bytes) -> bytes | None:
+        size = cast(int, self.redis.strlen(key))
+        if size > 0:
+            self._ensure_entry_fits(size, operation="load")
         return cast(bytes, self.redis.get(key))
 
     def exists(self, key: bytes) -> bool:
@@ -53,6 +68,14 @@ class RedisCacheBackend(CacheBackendProtocol):
 
     def close(self) -> None:
         self.redis.close()
+
+    def _ensure_entry_fits(self, size: int, *, operation: str) -> None:
+        if size > self.max_entry_bytes:
+            raise CacheEntryTooLargeError(
+                operation=operation,
+                actual_bytes=size,
+                max_entry_bytes=self.max_entry_bytes,
+            )
 
     def __enter__(self) -> "RedisCacheBackend":
         return self

--- a/cachepot/backend/sqlite.py
+++ b/cachepot/backend/sqlite.py
@@ -5,7 +5,11 @@ from datetime import datetime, timezone
 from types import TracebackType
 from typing import cast
 
-from cachepot.backend import CacheBackendProtocol
+from cachepot.backend import (
+    DEFAULT_MAX_ENTRY_BYTES,
+    CacheBackendProtocol,
+    CacheEntryTooLargeError,
+)
 from cachepot.expire import Expiry, to_timedelta
 
 ConnectionLike = str | pathlib.Path | sqlite3.Connection
@@ -54,7 +58,12 @@ class SQLiteCacheBackend(CacheBackendProtocol):
     _lock: threading.Lock
     _closed: bool
 
-    def __init__(self, conn: ConnectionLike) -> None:
+    def __init__(
+        self,
+        conn: ConnectionLike,
+        *,
+        max_entry_bytes: int = DEFAULT_MAX_ENTRY_BYTES,
+    ) -> None:
         if isinstance(conn, (str, pathlib.Path)):
             conn = _open_and_init(conn)
         else:
@@ -62,6 +71,7 @@ class SQLiteCacheBackend(CacheBackendProtocol):
         self._lock = threading.Lock()
         self.conn = conn
         self._closed = False
+        self.max_entry_bytes = max_entry_bytes
 
     def close(self) -> None:
         with self._lock:
@@ -90,6 +100,7 @@ class SQLiteCacheBackend(CacheBackendProtocol):
         *,
         expire_seconds: Expiry,
     ) -> None:
+        self._ensure_entry_fits(len(value), operation="save")
         with self._lock:
             self._check_open()
             expire_at = (
@@ -108,17 +119,48 @@ INSERT OR REPLACE INTO cachepot
         with self._lock:
             self._check_open()
             current_datetime = datetime.now(timezone.utc).isoformat()
-            result = self.conn.execute(
-                """\
-        SELECT value
-          FROM cachepot
-         WHERE key = ?
-           AND expire_at > ?""",
-                (key, current_datetime),
-            ).fetchone()
+            self._ensure_load_fits(key, current_datetime)
+            result = self._load_value_row(key, current_datetime)
         if result:
             return cast(bytes, result[0])
         return None
+
+    def _ensure_load_fits(self, key: bytes, current_datetime: str) -> None:
+        size_row = self.conn.execute(
+            """\
+    SELECT length(value)
+      FROM cachepot
+     WHERE key = ?
+       AND expire_at > ?""",
+            (key, current_datetime),
+        ).fetchone()
+        if size_row:
+            self._ensure_entry_fits(
+                cast(int, size_row[0]),
+                operation="load",
+            )
+
+    def _load_value_row(
+        self,
+        key: bytes,
+        current_datetime: str,
+    ) -> tuple[bytes] | None:
+        return self.conn.execute(
+            """\
+    SELECT value
+      FROM cachepot
+     WHERE key = ?
+       AND expire_at > ?""",
+            (key, current_datetime),
+        ).fetchone()
+
+    def _ensure_entry_fits(self, size: int, *, operation: str) -> None:
+        if size > self.max_entry_bytes:
+            raise CacheEntryTooLargeError(
+                operation=operation,
+                actual_bytes=size,
+                max_entry_bytes=self.max_entry_bytes,
+            )
 
     def exists(self, key: bytes) -> bool:
         with self._lock:

--- a/tests/backend/test_filesystem.py
+++ b/tests/backend/test_filesystem.py
@@ -10,6 +10,7 @@ from typing import BinaryIO, TextIO, cast
 
 import pytest
 
+from cachepot.backend import CacheEntryTooLargeError
 from cachepot.backend import filesystem as filesystem_backend
 from cachepot.backend.filesystem import FileSystemCacheBackend
 from cachepot.expire import to_timedelta
@@ -392,6 +393,29 @@ def test_exists_does_not_delete_expired_entry() -> None:
 
         assert not cachestore.exists(key)
         assert realpath.exists(), "exists() must not delete the file"
+
+
+def test_save_rejects_entries_larger_than_max_entry_bytes() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cachestore = FileSystemCacheBackend(tmpdir, max_entry_bytes=3)
+
+        with pytest.raises(CacheEntryTooLargeError, match="save"):
+            cachestore.save(b"key", b"toolarge", expire_seconds=60)
+
+
+def test_load_rejects_entries_larger_than_max_entry_bytes() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = pathlib.Path(tmpdir)
+        cachestore = FileSystemCacheBackend(cache_dir, max_entry_bytes=3)
+        key = b"collision-key"
+        key_path = _cache_entry_path(cache_dir, key)
+        expire_at = time.time() + 60
+        key_path.write_bytes(
+            struct.pack(_EXPIRY_HEADER_FORMAT, expire_at) + b"oversized",
+        )
+
+        with pytest.raises(CacheEntryTooLargeError, match="load"):
+            cachestore.load(key)
 
 
 def test_expiry_boundary_is_treated_as_expired(

--- a/tests/backend/test_redis.py
+++ b/tests/backend/test_redis.py
@@ -2,8 +2,10 @@ import time
 from datetime import timedelta
 from unittest.mock import MagicMock
 
+import pytest
 import redis
 
+from cachepot.backend import CacheEntryTooLargeError
 from cachepot.backend.redis import RedisCacheBackend
 
 
@@ -90,6 +92,7 @@ def test_save_zero_expire_skips_write() -> None:
     backend behaviour.
     """
     mock_redis = MagicMock()
+    mock_redis.strlen.return_value = 0
     mock_redis.get.return_value = None
     cachestore = RedisCacheBackend(mock_redis)
 
@@ -97,3 +100,24 @@ def test_save_zero_expire_skips_write() -> None:
 
     mock_redis.set.assert_not_called()
     assert cachestore.load(b"key") is None
+
+
+def test_save_rejects_entries_larger_than_max_entry_bytes() -> None:
+    mock_redis = MagicMock()
+    cachestore = RedisCacheBackend(mock_redis, max_entry_bytes=3)
+
+    with pytest.raises(CacheEntryTooLargeError, match="save"):
+        cachestore.save(b"key", b"toolarge", expire_seconds=60)
+
+    mock_redis.set.assert_not_called()
+
+
+def test_load_rejects_entries_larger_than_max_entry_bytes() -> None:
+    mock_redis = MagicMock()
+    mock_redis.strlen.return_value = 8
+    cachestore = RedisCacheBackend(mock_redis, max_entry_bytes=3)
+
+    with pytest.raises(CacheEntryTooLargeError, match="load"):
+        cachestore.load(b"key")
+
+    mock_redis.get.assert_not_called()

--- a/tests/backend/test_sqlite.py
+++ b/tests/backend/test_sqlite.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 import cachepot.backend.sqlite as sqlite_backend
+from cachepot.backend import CacheEntryTooLargeError
 from cachepot.backend.sqlite import SQLiteCacheBackend
 
 _CONTROLLED_CURRENT_TIME: list[datetime] = [datetime(1970, 1, 1)]
@@ -216,6 +217,36 @@ def test_exists_does_not_return_true_for_expired() -> None:
         assert cachestore.exists(b"k")
         time.sleep(2)
         assert not cachestore.exists(b"k")
+
+
+def test_save_rejects_entries_larger_than_max_entry_bytes() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name, max_entry_bytes=3)
+
+        with pytest.raises(CacheEntryTooLargeError, match="save"):
+            cachestore.save(b"k", b"toolarge", expire_seconds=60)
+
+
+def test_load_rejects_entries_larger_than_max_entry_bytes() -> None:
+    with tempfile.NamedTemporaryFile() as f:
+        cachestore = SQLiteCacheBackend(f.name, max_entry_bytes=3)
+        cachestore.conn.execute(
+            """\
+INSERT INTO cachepot
+            (key, value, expire_at)
+     VALUES (?, ?, ?)""",
+            (
+                b"k",
+                b"toolarge",
+                (
+                    datetime.now(timezone.utc) + timedelta(seconds=60)
+                ).isoformat(),
+            ),
+        )
+        cachestore.conn.commit()
+
+        with pytest.raises(CacheEntryTooLargeError, match="load"):
+            cachestore.load(b"k")
 
 
 def _thread_worker(cachestore: SQLiteCacheBackend, i: int) -> None:


### PR DESCRIPTION
## Why

Cache entries could be saved and later loaded without any size bound, so a single oversized entry could turn the cache into an unbounded memory consumer.

## What changed

- enforce a default `max_entry_bytes` limit of 8 MiB across filesystem, SQLite, and Redis backends
- reject oversized writes and check backend-side entry size before materializing cached payloads on load
- document the new size contract and add backend tests that cover oversized save/load rejection

## Verification

- `uv run ruff check cachepot example tests`
- `uv run mypy cachepot example tests`
- `uv run pytest`
