### PR TITLE
ci: enable branch coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True


### PR DESCRIPTION
## Summary

Enable coverage.py branch measurement for the existing pytest-cov coverage task.

Line coverage alone can report successful coverage while a conditional branch arm remains untested. Recording branch coverage makes those gaps visible in the existing coverage XML without adding dependencies or changing workflows.

## Verification

- `uv run --frozen poe coverage-xml`
