### PR TITLE
Use top-level cachepot imports in the example module

### DIFF
--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-from cachepot.backend.filesystem import FileSystemCacheBackend
+from cachepot import CacheStore, FileSystemCacheBackend
 from cachepot.serializer.json import JSONSerializer, JSONType
 from cachepot.serializer.pickle import PickleSerializer
 from cachepot.serializer.str import StringSerializer
-from cachepot.store import CacheStore
 
 
 class SimpleFileSystemCacheStore(CacheStore[str, Any]):
@@ -14,7 +13,7 @@ class SimpleFileSystemCacheStore(CacheStore[str, Any]):
         self,
         namespace: str,
         *,
-        directory: str = 'tmp',
+        directory: str = "tmp",
     ) -> None:
         super().__init__(
             namespace=namespace,
@@ -32,7 +31,7 @@ class FileSystemJSONCacheStore(CacheStore[str, JSONType]):
         self,
         namespace: str,
         *,
-        directory: str = 'tmp',
+        directory: str = "tmp",
     ) -> None:
         super().__init__(
             namespace=namespace,
@@ -44,10 +43,10 @@ class FileSystemJSONCacheStore(CacheStore[str, JSONType]):
 
 
 def example_usage() -> None:
-    cachestore = SimpleFileSystemCacheStore('example', directory='./tmp')
-    cachestore.put('x', 1)
-    assert cachestore.get('x') == 1
-    cachestore.delete('x')
-    assert cachestore.get('x') is None
-    assert cachestore.proxy(lambda: 3)(cache_key='y') == 3
-    assert cachestore.proxy(lambda: 3)(cache_key='y') == 3
+    cachestore = SimpleFileSystemCacheStore("example", directory="./tmp")
+    cachestore.put("x", 1)
+    assert cachestore.get("x") == 1
+    cachestore.delete("x")
+    assert cachestore.get("x") is None
+    assert cachestore.proxy(lambda: 3)(cache_key="y") == 3
+    assert cachestore.proxy(lambda: 3)(cache_key="y") == 3

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from example import (
     FileSystemJSONCacheStore,
     SimpleFileSystemCacheStore,
@@ -25,3 +27,9 @@ def test_example_usage_runs(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
 
     example_usage()
+
+
+def test_example_module_uses_top_level_cachepot_imports() -> None:
+    source = Path("example/__init__.py").read_text()
+
+    assert "from cachepot import CacheStore, FileSystemCacheBackend" in source


### PR DESCRIPTION
## Summary

Align the importable example module with the README's documented top-level `cachepot` import path.

## Changes

- switch `example/__init__.py` to import `CacheStore` and `FileSystemCacheBackend` from `cachepot`
- add a regression test that keeps the example module pinned to the top-level import path

## Testing

- [x] `uv run poe check`
- [x] `uv run poe test`

## Related issues

- None.
