### PR TITLE
Use top-level cachepot imports in example module

### DIFF
--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,10 +1,9 @@
 from typing import Any
 
-from cachepot.backend.filesystem import FileSystemCacheBackend
+from cachepot import CacheStore, FileSystemCacheBackend
 from cachepot.serializer.json import JSONSerializer, JSONType
 from cachepot.serializer.pickle import PickleSerializer
 from cachepot.serializer.str import StringSerializer
-from cachepot.store import CacheStore
 
 
 class SimpleFileSystemCacheStore(CacheStore[str, Any]):


### PR DESCRIPTION
## Why

`example/__init__.py` is documented in `example/README.md` as an importable, smoke-tested usage example. It built `CacheStore` and `FileSystemCacheBackend` from their internal module paths (`cachepot.store`, `cachepot.backend.filesystem`), while the main README documents importing both symbols from the top-level `cachepot` package as the canonical usage pattern:

```python
from cachepot import CacheStore, FileSystemCacheBackend
```

That left two competing, undocumented routes to the same public symbols: the README's top-level path and the example module's deep-import path. The repository already documents one deliberate deep-import exception (`PickleSerializer`, which is intentionally not exported at top level), but `CacheStore` and `FileSystemCacheBackend` had no such documented reason to bypass the top-level path, so the example's usage was effectively drift rather than an endorsed alternative. It also meant future moves of `store/__init__.py` or `backend/filesystem.py` would need to keep the deep paths working purely to avoid breaking published example code.

## What changed

`example/__init__.py` now imports `CacheStore` and `FileSystemCacheBackend` from the top-level `cachepot` package, matching the README's documented canonical path. `PickleSerializer`, `JSONSerializer`, `JSONType`, and `StringSerializer` imports are unchanged, since `PickleSerializer` is a documented deep-import exception and the others are not exported at top level.

## Verification

This was run in a network-restricted sandbox where a full `uv sync` against PyPI wasn't possible, so dependencies matching the versions pinned in `uv.lock` were loaded directly from a locally available wheel cache instead of a fresh install.

- `pytest tests/test_example.py -v` - 3 passed (`SimpleFileSystemCacheStore`, `FileSystemJSONCacheStore`, `example_usage()` all exercised at runtime through the new top-level import path).
- `pytest tests/ -q --ignore=tests/backend/test_redis.py --ignore=tests/test_store.py` - 57 passed. The two ignored modules fail to collect only because `redis` and `typing_extensions` aren't installable in this offline sandbox; unrelated to this change.
- `ruff check cachepot example tests` - all checks passed (matches the repo's `check` poe task).
- `ruff format` was not run against `example/` because the repo's own `format` poe task scopes formatting to `cachepot/` only; `example/`'s pre-existing single-quote style is unrelated to and unaffected by this change.
